### PR TITLE
Enable multi-style rounds and streamline signature library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Boxing-kickboxing-app
+# Bagwork Buddy App
+
+A sleek single-page experience that reimagines the Shot Caller website as an app-first interface with a premium training club aesthetic, now rebranded as Bagwork Buddy. Built with semantic HTML, modern CSS, and lightweight JavaScript interactions so it runs without a build step.
+
+## Getting started
+
+No build tooling is required. Simply open `index.html` in a browser, or serve the directory locally with any static web server.
+
+```bash
+python -m http.server 4173
+```
+
+Then visit [http://localhost:4173](http://localhost:4173).
+
+## Features
+
+- Responsive hero with immersive mock device UI and CTA buttons
+- Highlights grid showcasing app capabilities
+- Featured program cards with gradient artwork
+- Interactive live schedule filter for Muay Thai, strength, and recovery sessions
+- Coach spotlights with stylized portrait treatments
+- Membership pricing grid with tiered call-to-action buttons
+- Download section with tablet mockup and progress visualization
+- Auto-playing testimonial carousel with manual controls
+- Dark, polished visual system shaped by boutique gym inspiration
+- Custom Training Lab with selectable combinations, techniques, and smart round pacing
+- Signature style libraries for legendary fighters with auto-loaded drills and coaching notes
+- Save your own signature styles with custom move selections and coaching cues

--- a/app.js
+++ b/app.js
@@ -1,0 +1,1694 @@
+const nav = document.querySelector('.nav');
+const navToggle = document.querySelector('.nav-toggle');
+const navLinks = document.querySelector('.nav-links');
+const navCta = document.querySelector('.nav-cta');
+
+if (navToggle) {
+  navToggle.addEventListener('click', () => {
+    nav.classList.toggle('open');
+    const isExpanded = nav.classList.contains('open');
+    navToggle.setAttribute('aria-expanded', String(isExpanded));
+    navToggle.setAttribute('aria-label', isExpanded ? 'Close navigation' : 'Open navigation');
+    if (isExpanded) {
+      document.addEventListener('click', closeOnOutsideClick);
+    } else {
+      document.removeEventListener('click', closeOnOutsideClick);
+    }
+  });
+}
+
+function closeOnOutsideClick(event) {
+  if (!nav.contains(event.target)) {
+    nav.classList.remove('open');
+    navToggle.setAttribute('aria-expanded', 'false');
+    navToggle.setAttribute('aria-label', 'Open navigation');
+    document.removeEventListener('click', closeOnOutsideClick);
+  }
+}
+
+if (navLinks) {
+  navLinks.addEventListener('click', (event) => {
+    if (event.target instanceof HTMLAnchorElement) {
+      nav.classList.remove('open');
+      navToggle?.setAttribute('aria-expanded', 'false');
+      navToggle?.setAttribute('aria-label', 'Open navigation');
+    }
+  });
+}
+
+if (navCta) {
+  navCta.addEventListener('click', () => {
+    nav.classList.remove('open');
+    navToggle?.setAttribute('aria-expanded', 'false');
+    navToggle?.setAttribute('aria-label', 'Open navigation');
+  });
+}
+
+// Schedule filtering
+const filterButtons = document.querySelectorAll('.chip');
+const scheduleCards = document.querySelectorAll('.schedule-card');
+
+filterButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    const category = button.dataset.category;
+
+    filterButtons.forEach((b) => b.classList.remove('active'));
+    button.classList.add('active');
+
+    scheduleCards.forEach((card) => {
+      const cardCategory = card.dataset.category;
+      const shouldShow = category === 'all' || cardCategory === category;
+      card.style.display = shouldShow ? 'flex' : 'none';
+      card.setAttribute('aria-hidden', shouldShow ? 'false' : 'true');
+    });
+  });
+});
+
+// Testimonials carousel
+const testimonials = Array.from(document.querySelectorAll('.testimonial'));
+const prevButton = document.querySelector('.carousel-control.prev');
+const nextButton = document.querySelector('.carousel-control.next');
+let currentIndex = testimonials.findIndex((testimonial) => testimonial.classList.contains('active'));
+let autoplayId = null;
+
+function updateTestimonials(index) {
+  testimonials.forEach((testimonial, idx) => {
+    testimonial.classList.toggle('active', idx === index);
+  });
+  currentIndex = index;
+}
+
+function showNext() {
+  const nextIndex = (currentIndex + 1) % testimonials.length;
+  updateTestimonials(nextIndex);
+}
+
+function showPrev() {
+  const prevIndex = (currentIndex - 1 + testimonials.length) % testimonials.length;
+  updateTestimonials(prevIndex);
+}
+
+function startAutoplay() {
+  stopAutoplay();
+  autoplayId = window.setInterval(showNext, 7000);
+}
+
+function stopAutoplay() {
+  if (autoplayId) {
+    window.clearInterval(autoplayId);
+  }
+}
+
+if (prevButton && nextButton && testimonials.length > 0) {
+  prevButton.addEventListener('click', () => {
+    showPrev();
+    startAutoplay();
+  });
+
+  nextButton.addEventListener('click', () => {
+    showNext();
+    startAutoplay();
+  });
+
+  const carousel = document.querySelector('.testimonial-carousel');
+  if (carousel) {
+    carousel.addEventListener('mouseenter', stopAutoplay);
+    carousel.addEventListener('mouseleave', startAutoplay);
+  }
+
+  startAutoplay();
+}
+
+const trainingLab = document.querySelector('.training-lab');
+
+if (trainingLab) {
+  const combinationLibraryData = [
+    {
+      id: 'jab-cross',
+      name: 'Jab → Cross',
+      sequence: ['Jab', 'Cross'],
+      category: 'Hands',
+      description: 'Fundamental 1-2 to set range and gauge distance.',
+    },
+    {
+      id: 'jab-cross-hook-low-kick',
+      name: 'Jab → Cross → Lead Hook → Outside Low Kick',
+      sequence: ['Jab', 'Cross', 'Lead Hook', 'Outside Low Kick'],
+      category: 'Hands + Kick',
+      description: 'Rip to the head before chopping the calf.',
+    },
+    {
+      id: 'jab-cross-right-body-kick',
+      name: 'Jab → Cross → Right Body Kick',
+      sequence: ['Jab', 'Cross', 'Right Body Kick'],
+      category: 'Level Change',
+      description: 'Pin the guard then wrap to the ribs.',
+    },
+    {
+      id: 'jab-cross-right-knee',
+      name: 'Jab → Cross → Rear Knee',
+      sequence: ['Jab', 'Cross', 'Rear Knee'],
+      category: 'Hands + Knee',
+      description: 'Close distance and spear the midline.',
+    },
+    {
+      id: 'jab-cross-left-hook-elbow',
+      name: 'Jab → Cross → Lead Hook → Horizontal Elbow',
+      sequence: ['Jab', 'Cross', 'Lead Hook', 'Horizontal Elbow'],
+      category: 'Elbows',
+      description: 'Box your way in and slice on the break.',
+    },
+    {
+      id: 'jab-cross-roll-cross',
+      name: 'Jab → Cross → Slip Roll → Cross',
+      sequence: ['Jab', 'Cross', 'Slip Roll', 'Cross'],
+      category: 'Defense',
+      description: 'Add head movement before returning fire.',
+    },
+    {
+      id: 'jab-cross-switch-kick',
+      name: 'Jab → Cross → Switch Kick',
+      sequence: ['Jab', 'Cross', 'Switch Kick'],
+      category: 'Switch Kick',
+      description: 'Hide the hip switch behind straight punches.',
+    },
+    {
+      id: 'lead-teep-cross-left-hook-low-kick',
+      name: 'Lead Teep → Cross → Lead Hook → Inside Low Kick',
+      sequence: ['Lead Teep', 'Cross', 'Lead Hook', 'Inside Low Kick'],
+      category: 'Teep Setups',
+      description: 'Off-balance first, then attack high and low.',
+    },
+    {
+      id: 'cross-hook-high-kick',
+      name: 'Cross → Lead Hook → Head Kick',
+      sequence: ['Cross', 'Lead Hook', 'Head Kick'],
+      category: 'High Kick',
+      description: 'Hide the high kick behind tight boxing.',
+    },
+    {
+      id: 'jab-step-elbow-right-knee',
+      name: 'Jab → Step-In Elbow → Rear Knee',
+      sequence: ['Jab', 'Step-In Elbow', 'Rear Knee'],
+      category: 'Clinch Entry',
+      description: 'Crash the pocket with elbows before securing the knee.',
+    },
+    {
+      id: 'jab-cross-lead-uppercut-cross-body-kick',
+      name: 'Jab → Cross → Lead Uppercut → Cross → Body Kick',
+      sequence: ['Jab', 'Cross', 'Lead Uppercut', 'Cross', 'Right Body Kick'],
+      category: 'Power',
+      description: 'Blend levels before finishing with power to the body.',
+    },
+    {
+      id: 'cross-hook-elbow-knee',
+      name: 'Cross → Lead Hook → Downward Elbow → Lead Knee',
+      sequence: ['Cross', 'Lead Hook', 'Downward Elbow', 'Lead Knee'],
+      category: 'Clinch Exit',
+      description: 'Smash on entry and finish from the clinch.',
+    },
+    {
+      id: 'jab-cross-inside-low-kick-cross',
+      name: 'Jab → Cross → Inside Low Kick → Cross',
+      sequence: ['Jab', 'Cross', 'Inside Low Kick', 'Cross'],
+      category: 'Counters',
+      description: 'Attack the inside leg and punish the reset.',
+    },
+    {
+      id: 'jab-cross-spin-elbow',
+      name: 'Jab → Cross → Spinning Elbow',
+      sequence: ['Jab', 'Cross', 'Spinning Elbow'],
+      category: 'Advanced',
+      description: 'Set up flair offense after straight shots.',
+    },
+    {
+      id: 'double-jab-cross-pivot',
+      name: 'Double Jab → Cross → Pivot Step',
+      sequence: ['Double Jab', 'Cross', 'Pivot Step'],
+      category: 'Footwork',
+      description: 'Float like Ali—sting, finish, and angle off the line.',
+    },
+    {
+      id: 'mcgregor-pull-counter',
+      name: 'Southpaw Jab → Pull Counter Left → Lead Hook',
+      sequence: ['Southpaw Jab', 'Pull Counter Left', 'Lead Hook'],
+      category: 'Counter Striking',
+      description: 'Draw a reach, sit back, and snipe with the left before wrapping the hook.',
+    },
+    {
+      id: 'mcgregor-teep-left-cross',
+      name: 'Lead Teep → Tempo Step → Cross',
+      sequence: ['Lead Teep', 'Tempo Step', 'Cross'],
+      category: 'Range Control',
+      description: 'Stab the teep, step into range, and fire the straight left down the middle.',
+    },
+    {
+      id: 'mcgregor-angle-exit',
+      name: 'Southpaw Jab → Cross → Pivot Step → Switch Kick',
+      sequence: ['Southpaw Jab', 'Cross', 'Pivot Step', 'Switch Kick'],
+      category: 'Angle & Finish',
+      description: 'Touch with the jab, blast the left, then exit with an angled high kick.',
+    },
+    {
+      id: 'peekaboo-slip-shovel-hook-cross',
+      name: 'Slip → Lead Shovel Hook → Cross → Lead Hook',
+      sequence: ['Slip Roll', 'Lead Shovel Hook', 'Cross', 'Lead Hook'],
+      category: 'Peekaboo',
+      description: 'Tyson-style slip inside then rip head and body.',
+    },
+    {
+      id: 'peekaboo-duck-uppercut-hook-body',
+      name: 'Slip → Rear Uppercut → Lead Hook → Lead Body Hook',
+      sequence: ['Slip Roll', 'Rear Uppercut', 'Lead Hook', 'Lead Body Hook'],
+      category: 'Power',
+      description: 'Change levels and explode through the guard.',
+    },
+    {
+      id: 'buakaw-teep-lowkick-switchknee',
+      name: 'Lead Teep → Outside Low Kick → Switch Knee',
+      sequence: ['Lead Teep', 'Outside Low Kick', 'Switch Knee'],
+      category: 'Muay Thai Power',
+      description: 'Buakaw rhythm—teep, chop the leg, then spear the knee.',
+    },
+    {
+      id: 'buakaw-clinch-elbow-knee',
+      name: 'Buakaw Clinch Smash',
+      sequence: ['Clinch Entry', 'Horizontal Elbow', 'Rear Knee', 'Clinch Break'],
+      category: 'Clinch',
+      description: 'Secure the tie and finish with punishing knees and elbows.',
+    },
+    {
+      id: 'saenchai-teep-sweep-question',
+      name: 'Lead Teep → Foot Sweep → Question Mark Kick',
+      sequence: ['Lead Teep', 'Foot Sweep', 'Question Mark Kick'],
+      category: 'Showmanship',
+      description: 'Saenchai wizardry blending balance breaks with deception.',
+    },
+    {
+      id: 'saenchai-step-elbow-spin',
+      name: 'Pivot Step → Step-In Elbow → Spinning Elbow',
+      sequence: ['Pivot Step', 'Step-In Elbow', 'Spinning Elbow'],
+      category: 'Creativity',
+      description: 'Angle off then slice through with flowing elbows.',
+    },
+    {
+      id: 'lomachenko-double-jab-angle-cross',
+      name: 'Double Jab → Pivot Step → Cross → Lead Hook',
+      sequence: ['Double Jab', 'Pivot Step', 'Cross', 'Lead Hook'],
+      category: 'Angles',
+      description: 'Southpaw Loma step to the outside before finishing.',
+    },
+    {
+      id: 'lomachenko-roll-body-head',
+      name: 'Jab → Slip Roll → Rear Uppercut → Pivot Step → Lead Hook',
+      sequence: ['Jab', 'Slip Roll', 'Rear Uppercut', 'Pivot Step', 'Lead Hook'],
+      category: 'Rhythm',
+      description: 'Layer level changes with constant exits off the center.',
+    },
+    {
+      id: 'joanna-volume-flow',
+      name: 'Jab → Cross → Lead Hook → Rear Teep → Switch Kick',
+      sequence: ['Jab', 'Cross', 'Lead Hook', 'Rear Teep', 'Switch Kick'],
+      category: 'Volume',
+      description: 'Jedrzejczyk pace—mix relentless hands with kicking flow.',
+    },
+    {
+      id: 'joanna-clinch-barrage',
+      name: 'Joanna Clinch Barrage',
+      sequence: ['Clinch Entry', 'Horizontal Elbow', 'Rear Knee', 'Clinch Break'],
+      category: 'Clinch Volume',
+      description: 'Chain short elbows and knees before resetting distance.',
+    },
+    {
+      id: 'mayweather-shoulder-roll-counter',
+      name: 'Shoulder Roll → Cross → Check Hook',
+      sequence: ['Shoulder Roll', 'Cross', 'Check Hook'],
+      category: 'Shell Counter',
+      description: 'Slip the shot, fire the right hand, and angle off with the check hook.',
+    },
+    {
+      id: 'mayweather-body-head',
+      name: 'Lead Body Hook → Rear Uppercut → Check Hook',
+      sequence: ['Lead Body Hook', 'Rear Uppercut', 'Check Hook'],
+      category: 'Body to Head',
+      description: 'Dig the liver, shoot the uppercut, and finish with a sharp exit hook.',
+    },
+    {
+      id: 'mayweather-jab-clinch-break',
+      name: 'Jab → Shoulder Roll → Lead Hook → Clinch Break',
+      sequence: ['Jab', 'Shoulder Roll', 'Lead Hook', 'Clinch Break'],
+      category: 'Control & Reset',
+      description: 'Touch the jab, melt into the shell, counter, then break clean.',
+    },
+    {
+      id: 'ploy-angle-kick-finish',
+      name: 'Southpaw Jab → Cross → Pivot Step → Left Body Kick',
+      sequence: ['Southpaw Jab', 'Cross', 'Pivot Step', 'Left Body Kick'],
+      category: 'Southpaw Control',
+      description: 'Steal the outside line then whip the left kick through the ribs.',
+    },
+    {
+      id: 'ploy-frame-elbow',
+      name: 'Lead Teep → Long Guard → Horizontal Elbow',
+      sequence: ['Lead Teep', 'Long Guard', 'Horizontal Elbow'],
+      category: 'Frame & Fire',
+      description: 'Freeze the guard with a frame before stepping through with the elbow.',
+    },
+    {
+      id: 'ploy-clinch-knee',
+      name: 'Southpaw Jab → Rear Hook → Clinch Entry → Rear Knee',
+      sequence: ['Southpaw Jab', 'Rear Hook', 'Clinch Entry', 'Rear Knee'],
+      category: 'Clinch Punish',
+      description: 'Box your way in then feed a knee straight up the middle.',
+    },
+    {
+      id: 'marcus-breath-flow',
+      name: 'Lead Teep → Rear Teep → Breath Reset',
+      sequence: ['Lead Teep', 'Rear Teep', 'Breath Reset'],
+      category: 'Breathwork Flow',
+      description: 'Control tempo with alternating teeps before settling into your breath.',
+    },
+    {
+      id: 'marcus-shield-return',
+      name: 'Long Guard → Breath Reset → Cross',
+      sequence: ['Long Guard', 'Breath Reset', 'Cross'],
+      category: 'Shield & Return',
+      description: 'Frame the guard, re-center, then snap a sharp cross down the pipe.',
+    },
+    {
+      id: 'marcus-slow-burn',
+      name: 'Tempo Step → Jab → Cross → Breath Reset',
+      sequence: ['Tempo Step', 'Jab', 'Cross', 'Breath Reset'],
+      category: 'Pace Control',
+      description: 'Step with intention, strike, then extend the exhale to stay composed.',
+    },
+    {
+      id: 'liv-power-ladder',
+      name: 'Rear Uppercut → Lead Hook → Rear Knee → Switch Kick',
+      sequence: ['Rear Uppercut', 'Lead Hook', 'Rear Knee', 'Switch Kick'],
+      category: 'Power Ladder',
+      description: 'Climb from hands to knees to kicks without losing power output.',
+    },
+    {
+      id: 'liv-low-high-finish',
+      name: 'Outside Low Kick → Cross → Head Kick',
+      sequence: ['Outside Low Kick', 'Cross', 'Head Kick'],
+      category: 'Low-High Finish',
+      description: 'Chop the base, punch the guard, then take the head off the centerline.',
+    },
+    {
+      id: 'liv-clinch-drive',
+      name: 'Clinch Entry → Rear Knee → Horizontal Elbow → Clinch Break',
+      sequence: ['Clinch Entry', 'Rear Knee', 'Horizontal Elbow', 'Clinch Break'],
+      category: 'Clinch Power',
+      description: 'Secure posture, drive knees, and exit with a slicing elbow.',
+    },
+  ];
+
+  const techniqueLibraryData = [
+    { id: 'jab', name: 'Jab', category: 'Hands', description: 'Sharp lead straight with snap.' },
+    { id: 'cross', name: 'Cross', category: 'Hands', description: 'Rear straight with full rotation.' },
+    { id: 'lead-hook', name: 'Lead Hook', category: 'Hands', description: 'Tight hook, elbow level with fist.' },
+    { id: 'rear-hook', name: 'Rear Hook', category: 'Hands', description: 'Power hook from the back side.' },
+    { id: 'lead-uppercut', name: 'Lead Uppercut', category: 'Hands', description: 'Rise up the centerline.' },
+    { id: 'rear-uppercut', name: 'Rear Uppercut', category: 'Hands', description: 'Explosive vertical shot.' },
+    { id: 'southpaw-jab', name: 'Southpaw Jab', category: 'Hands', description: 'Right-hand lead flick from a southpaw stance.' },
+    { id: 'lead-body-hook', name: 'Lead Body Hook', category: 'Body Shots', description: 'Dig to the liver with bend in the knees.' },
+    { id: 'rear-body-hook', name: 'Rear Body Hook', category: 'Body Shots', description: 'Whip to the ribs off a pivot.' },
+    { id: 'lead-teep', name: 'Lead Teep', category: 'Kicks', description: 'Long guard teep to manage range.' },
+    { id: 'rear-teep', name: 'Rear Teep', category: 'Kicks', description: 'Power teep to the midsection.' },
+    { id: 'switch-kick', name: 'Switch Kick', category: 'Kicks', description: 'Switch stance and whip high or mid.' },
+    { id: 'outside-low-kick', name: 'Outside Low Kick', category: 'Kicks', description: 'Chop the calf with shin.' },
+    { id: 'inside-low-kick', name: 'Inside Low Kick', category: 'Kicks', description: 'Lift the leg and slice the inner thigh.' },
+    { id: 'head-kick', name: 'Head Kick', category: 'Kicks', description: 'High roundhouse to the temple.' },
+    { id: 'question-mark-kick', name: 'Question Mark Kick', category: 'Kicks', description: 'Disguise low then whip high in one motion.' },
+    { id: 'left-body-kick', name: 'Left Body Kick', category: 'Kicks', description: 'Southpaw rear kick wrapping into the ribs.' },
+    { id: 'lead-knee', name: 'Lead Knee', category: 'Knees', description: 'Step up and spear through the core.' },
+    { id: 'rear-knee', name: 'Rear Knee', category: 'Knees', description: 'Drive hips forward off the rear leg.' },
+    { id: 'switch-knee', name: 'Switch Knee', category: 'Knees', description: 'Hop-switch and lance the knee straight through.' },
+    { id: 'horizontal-elbow', name: 'Horizontal Elbow', category: 'Elbows', description: 'Slash across with forearm parallel to floor.' },
+    { id: 'up-elbow', name: 'Up Elbow', category: 'Elbows', description: 'Rip vertically through the guard.' },
+    { id: 'downward-elbow', name: 'Downward Elbow', category: 'Elbows', description: 'Drop the elbow over the brow.' },
+    { id: 'spinning-elbow', name: 'Spinning Elbow', category: 'Elbows', description: 'Turn through and land the point of the elbow.' },
+    { id: 'superman-punch', name: 'Superman Punch', category: 'Hands', description: 'Explosive airborne straight punch.' },
+    { id: 'double-jab', name: 'Double Jab', category: 'Hands', description: 'Pop rapid 1-1s to disrupt rhythm and claim range.' },
+    { id: 'lead-shovel-hook', name: 'Lead Shovel Hook', category: 'Body Shots', description: '45° lead hand rip that splits guard and digs the body.' },
+    { id: 'pivot-step', name: 'Pivot Step', category: 'Footwork', description: 'Spin around the lead foot to create sharp angles.' },
+    { id: 'tempo-step', name: 'Tempo Step', category: 'Footwork', description: 'Step in and out with measured cadence to manage pace.' },
+    { id: 'foot-sweep', name: 'Foot Sweep', category: 'Footwork', description: 'Hook and guide their base leg off-line.' },
+    { id: 'long-guard', name: 'Long Guard', category: 'Defense', description: 'Frame and shield to absorb strikes.' },
+    { id: 'check-kick', name: 'Check Kick', category: 'Defense', description: 'Lift the shin to block low kicks.' },
+    { id: 'slip-roll', name: 'Slip Roll', category: 'Defense', description: 'Slip inside and roll under the hook.' },
+    { id: 'shoulder-roll', name: 'Shoulder Roll', category: 'Defense', description: 'Roll the rear shoulder to deflect and counter.' },
+    { id: 'clinch-entry', name: 'Clinch Entry', category: 'Clinch', description: 'Secure inside position with posture.' },
+    { id: 'clinch-break', name: 'Clinch Break', category: 'Clinch', description: 'Frame off and exit safely.' },
+    { id: 'breath-reset', name: 'Breath Reset', category: 'Recovery', description: 'Slow nasal inhale with extended exhale to drop tension.' },
+    { id: 'pull-counter-left', name: 'Pull Counter Left', category: 'Counters', description: 'Lean back from the jab and rocket the straight left.' },
+    { id: 'check-hook', name: 'Check Hook', category: 'Hands', description: 'Pivot off the lead foot while whipping the hook.' },
+  ];
+
+  const baseStyleLibraryData = [
+    {
+      id: 'muhammad-ali',
+      name: 'Muhammad Ali',
+      discipline: 'Heavyweight Boxing',
+      focus: 'Footwork & Feints',
+      headline: 'Float outside with fast doubles then pivot off.',
+      summary:
+        'Stay light on the feet, set rhythm with rapid jabs, and disappear off the line before a counter can chase you.',
+      combos: ['double-jab-cross-pivot', 'jab-cross-roll-cross'],
+      techniques: ['double-jab', 'pivot-step', 'long-guard'],
+      coaching: [
+        'Glide on the balls of your feet and keep the shoulders relaxed so the jab stays effortless.',
+        'Snap the double jab to blind their vision before stinging with the cross.',
+        'Pivot immediately after the finish so you are scoring while they swing at air.',
+      ],
+    },
+    {
+      id: 'mike-tyson',
+      name: 'Mike Tyson',
+      discipline: 'Peekaboo Boxing',
+      focus: 'Slip & Rip Power',
+      headline: 'Explode from a tight shell with ripping hooks.',
+      summary:
+        'Live in the pocket with head movement, sitting low in the legs so you can spring upward with crushing power.',
+      combos: ['peekaboo-slip-shovel-hook-cross', 'peekaboo-duck-uppercut-hook-body'],
+      techniques: ['lead-shovel-hook', 'lead-body-hook', 'slip-roll'],
+      coaching: [
+        'Slip before you punch so momentum is already loaded into the hips.',
+        'Transfer weight hip-to-hip and keep elbows tight as you rip hooks upstairs and downstairs.',
+        'Finish combinations with another slip or pivot to stay a step ahead of the return.',
+      ],
+    },
+    {
+      id: 'buakaw-banchamek',
+      name: 'Buakaw Banchamek',
+      discipline: 'Muay Thai Powerhouse',
+      focus: 'Teep • Low Kick • Knees',
+      headline: 'Own the center with teeps, chops, and punishing knees.',
+      summary:
+        'Control range with a stiff teep, batter their base with low kicks, then crash into the clinch to finish with knees.',
+      combos: ['buakaw-teep-lowkick-switchknee', 'jab-cross-right-body-kick', 'buakaw-clinch-elbow-knee'],
+      techniques: ['lead-teep', 'outside-low-kick', 'switch-knee', 'horizontal-elbow'],
+      coaching: [
+        'Post a long guard, stabbing the teep to send opponents backward before they can plant.',
+        'Follow straight punches with low kicks to deaden the lead leg and slow their advance.',
+        'Once they shell, lock the clinch, turn their posture, and drive the knee straight through the core.',
+      ],
+    },
+    {
+      id: 'saenchai',
+      name: 'Saenchai',
+      discipline: 'Muay Thai Showman',
+      focus: 'Balance Traps & Creativity',
+      headline: 'Play with rhythm using sweeps and spinning elbows.',
+      summary:
+        'Disrupt balance with playful teeps and sweeps, then dazzle with spins that arrive from impossible angles.',
+      combos: ['saenchai-teep-sweep-question', 'saenchai-step-elbow-spin', 'lead-teep-cross-left-hook-low-kick'],
+      techniques: ['foot-sweep', 'question-mark-kick', 'pivot-step', 'spinning-elbow'],
+      coaching: [
+        'Stay bouncing on the lead leg so you can hop into teeps or step-around sweeps at any moment.',
+        'Sell the question mark kick with a low-line feint before whipping high to the temple.',
+        'Use pivots into step-in elbows to keep opponents biting on every fainted direction change.',
+      ],
+    },
+    {
+      id: 'coach-ploy',
+      name: 'Coach Ploy',
+      discipline: 'Southpaw Savant',
+      focus: 'Angles & Clinch Knees',
+      headline: 'Control the pocket from the left side.',
+      summary:
+        'Layer southpaw jabs with pivots, frame off the guard, and crash into knees before opponents reclaim balance.',
+      combos: ['ploy-angle-kick-finish', 'ploy-frame-elbow', 'ploy-clinch-knee'],
+      techniques: ['southpaw-jab', 'pivot-step', 'left-body-kick', 'rear-knee'],
+      coaching: [
+        'Snap the southpaw jab to draw their guard high, then pivot before they can reset their feet.',
+        'Frame with the long guard to freeze them before stepping through with slicing elbows.',
+        'Finish exchanges by clinching up and feeding your rear knee through the center line.',
+      ],
+    },
+    {
+      id: 'coach-marcus',
+      name: 'Coach Marcus',
+      discipline: 'Performance Breathwork',
+      focus: 'Tempo & Recovery',
+      headline: 'Own the pace with intentional breathing.',
+      summary:
+        'Alternate sharp teeps with structured breathing resets so every combination ends with calm shoulders and clear focus.',
+      combos: ['marcus-breath-flow', 'marcus-shield-return', 'marcus-slow-burn'],
+      techniques: ['lead-teep', 'rear-teep', 'breath-reset', 'long-guard', 'tempo-step'],
+      coaching: [
+        'Keep inhales through the nose and extend the exhale through each strike to stay relaxed.',
+        'After framing with the long guard, drop the shoulders before sending the cross back down the middle.',
+        'Use the tempo step to reset stance and heart rate so every burst starts from balance.',
+      ],
+    },
+    {
+      id: 'coach-liv',
+      name: 'Coach Liv',
+      discipline: 'Hybrid Strength',
+      focus: 'Power Output & Drive',
+      headline: 'Build fight-ending power from the floor up.',
+      summary:
+        'Blend explosive uppercuts, low kicks, and knees to keep the engine revving while reinforcing strong positional frames.',
+      combos: ['liv-power-ladder', 'liv-low-high-finish', 'liv-clinch-drive'],
+      techniques: ['rear-uppercut', 'lead-hook', 'rear-knee', 'switch-kick', 'tempo-step'],
+      coaching: [
+        'Sit into your hips before the uppercut so the kinetic chain fires through every strike.',
+        'Chop low then rip high without telegraphing—stay rooted through the floor.',
+        'When you clinch, lock posture and drive the knee upward before ripping the elbow on exit.',
+      ],
+    },
+    {
+      id: 'vasiliy-lomachenko',
+      name: 'Vasiliy Lomachenko',
+      discipline: 'Matrix Boxing',
+      focus: 'Angles & Volume',
+      headline: 'Turn the corner after every touch.',
+      summary:
+        'Touch in bunches, exit off-center, and reappear on blind sides before the guard can reset.',
+      combos: ['lomachenko-double-jab-angle-cross', 'lomachenko-roll-body-head', 'double-jab-cross-pivot'],
+      techniques: ['double-jab', 'pivot-step', 'slip-roll', 'lead-hook'],
+      coaching: [
+        'Keep punches relaxed so you can immediately flow into the next angle change.',
+        'Use the pivot step after the double jab to show up on their flank with a clean line.',
+        'Blend head and body touches while your feet never stay planted in front.',
+      ],
+    },
+    {
+      id: 'joanna-jedrzejczyk',
+      name: 'Joanna Jędrzejczyk',
+      discipline: 'Striking Queen',
+      focus: 'Relentless Pace & Clinch Strikes',
+      headline: 'Drown opponents in layered volume.',
+      summary:
+        'Pepper with long combinations, finish with kicks, and punish inside the clinch before exiting clean.',
+      combos: ['joanna-volume-flow', 'jab-cross-switch-kick', 'joanna-clinch-barrage'],
+      techniques: ['rear-teep', 'switch-kick', 'horizontal-elbow', 'switch-knee'],
+      coaching: [
+        'Keep your stance active and elbows stacked so punches can chain without breaks.',
+        'Seal combinations with a kick to create distance before the counter comes back.',
+        'Frame the collar tie in the clinch and fire rapid knees before snapping out to range.',
+      ],
+    },
+    {
+      id: 'conor-mcgregor',
+      name: 'Conor McGregor',
+      discipline: 'Notorious Southpaw',
+      focus: 'Precision & Pull Counters',
+      headline: 'Snatch openings with surgical straight lefts.',
+      summary:
+        'Control range with a long southpaw stance, front kicks to the gut, and devastating pull-counter straight lefts that punish every reach.',
+      combos: ['mcgregor-pull-counter', 'mcgregor-teep-left-cross', 'mcgregor-angle-exit'],
+      techniques: ['southpaw-jab', 'pull-counter-left', 'tempo-step', 'switch-kick'],
+      coaching: [
+        'Keep your weight on the back foot so you can slide just out of range and return fire instantly.',
+        'Use the lead teep to manage distance before stepping in behind the straight left.',
+        'After every scoring shot, pivot off to the outside to deny the counter lane.',
+      ],
+    },
+    {
+      id: 'floyd-mayweather',
+      name: 'Floyd Mayweather Jr.',
+      discipline: 'Philly Shell Maestro',
+      focus: 'Defense & Precision Counters',
+      headline: 'Stay untouchable and answer every touch.',
+      summary:
+        'Live behind the shoulder roll, draw misses, and answer with pinpoint straight rights, check hooks, and body-head work that keeps opponents second-guessing.',
+      combos: ['mayweather-shoulder-roll-counter', 'mayweather-body-head', 'mayweather-jab-clinch-break'],
+      techniques: ['shoulder-roll', 'check-hook', 'lead-body-hook', 'rear-uppercut'],
+      coaching: [
+        'Let punches glance off the shoulder roll while you line up the counter straight.',
+        'Rip the body first to make the guard crumble before snapping the hook upstairs.',
+        'When traffic gets crowded, clinch, break clean, and reset the distance on your own terms.',
+      ],
+    },
+  ];
+
+  const CUSTOM_STYLE_STORAGE_KEY = 'bagwork-buddy-custom-styles';
+  const supportsStorage = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+  let customStyleLibraryData = supportsStorage ? loadCustomStyles() : [];
+  let styleLibraryData = [...baseStyleLibraryData, ...customStyleLibraryData];
+  const selectedStyleIds = new Set();
+
+  const combinationMap = new Map(combinationLibraryData.map((combo) => [combo.id, combo]));
+  const techniqueMap = new Map(techniqueLibraryData.map((tech) => [tech.id, tech]));
+
+  const styleContainer = document.getElementById('styleLibrary');
+  const clearStylesButton = document.getElementById('clearStyles');
+  const styleInstructions = document.getElementById('styleInstructions');
+  const defaultStyleInstructions = styleInstructions?.innerHTML ?? '';
+  const customStyleBuilder = document.getElementById('customStyleBuilder');
+  const customStyleToggle = document.getElementById('customStyleToggle');
+  const customStylePanel = document.getElementById('customStylePanel');
+  const customStyleForm = document.getElementById('customStyleForm');
+  const customStyleMessage = document.getElementById('customStyleMessage');
+  const customComboList = document.getElementById('customComboList');
+  const customTechniqueList = document.getElementById('customTechniqueList');
+  const customStyleUseSelection = document.getElementById('customStyleUseSelection');
+  const comboCount = document.getElementById('comboCount');
+  const techniqueCount = document.getElementById('techniqueCount');
+  const startButton = document.getElementById('startRound');
+  const pauseButton = document.getElementById('pauseRound');
+  const resetButton = document.getElementById('resetRound');
+  const nextButton = document.getElementById('nextCall');
+  const clearHistoryButton = document.getElementById('clearHistory');
+  const roundLengthSelect = document.getElementById('roundLength');
+  const callRateInput = document.getElementById('callRate');
+  const restLengthInput = document.getElementById('restLength');
+  const allowRepeatsCheckbox = document.getElementById('allowRepeats');
+  const callHistoryList = document.getElementById('callHistory');
+  const timerDisplay = document.getElementById('timerDisplay');
+  const phaseIndicator = document.getElementById('roundPhase');
+  const callDisplay = document.querySelector('.call-display');
+  const callSequence = document.getElementById('activeCall');
+  const callTags = document.getElementById('activeTags');
+
+  const state = {
+    mode: 'idle',
+    isPaused: false,
+    roundDurationMs: 0,
+    restDurationMs: 0,
+    callIntervalMs: 0,
+    remainingMs: 0,
+    phaseEndsAt: 0,
+    timerInterval: null,
+    callInterval: null,
+    pool: [],
+    availablePool: [],
+    allowRepeats: true,
+  };
+
+  let audioContext = null;
+
+  renderCustomBuilderList(combinationLibraryData, customComboList, 'combo');
+  renderCustomBuilderList(techniqueLibraryData, customTechniqueList, 'technique');
+  refreshStyleLibrary({ maintainSelection: false });
+  updateSelectionSummary();
+  renderStyleInstructions();
+  initializeTimerDisplay();
+
+  startButton?.addEventListener('click', startRound);
+  pauseButton?.addEventListener('click', togglePause);
+  resetButton?.addEventListener('click', resetRound);
+  nextButton?.addEventListener('click', handleNextCall);
+  clearHistoryButton?.addEventListener('click', clearHistory);
+  clearStylesButton?.addEventListener('click', clearAllStyles);
+  customStyleToggle?.addEventListener('click', () => toggleCustomStylePanel());
+  customStyleForm?.addEventListener('submit', handleCustomStyleSubmit);
+  customStyleUseSelection?.addEventListener('click', useCurrentSelectionsForCustomStyle);
+
+  if (customStyleMessage) {
+    showCustomStyleMessage('', false);
+  }
+
+  roundLengthSelect?.addEventListener('change', () => {
+    const minutes = clampToRange(roundLengthSelect.value, 1, 5);
+    roundLengthSelect.value = String(minutes);
+    if (state.mode === 'idle') {
+      state.remainingMs = minutes * 60000;
+      updateTimerDisplay();
+    }
+  });
+
+  callRateInput?.addEventListener('change', () => {
+    const calls = clampToRange(callRateInput.value, 4, 30);
+    callRateInput.value = String(calls);
+  });
+
+  restLengthInput?.addEventListener('change', () => {
+    const restSeconds = clampToRange(restLengthInput.value, 0, 180);
+    restLengthInput.value = String(restSeconds);
+  });
+
+  function renderStyleLibrary(data) {
+    if (!styleContainer) return;
+    styleContainer.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    data.forEach((style) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'style-card';
+      button.dataset.styleId = style.id;
+      button.dataset.styleSource = style.isCustom ? 'custom' : 'preset';
+      button.setAttribute('role', 'listitem');
+      const isActive = selectedStyleIds.has(style.id);
+      button.setAttribute('aria-pressed', String(isActive));
+      if (isActive) {
+        button.classList.add('active');
+      }
+
+      const topRow = document.createElement('div');
+      topRow.className = 'style-card-top';
+
+      const name = document.createElement('span');
+      name.className = 'style-name';
+      name.textContent = style.name;
+      topRow.appendChild(name);
+
+      const tagCluster = document.createElement('div');
+      tagCluster.className = 'style-card-tags';
+
+      const focusPill = document.createElement('span');
+      focusPill.className = 'style-pill';
+      focusPill.textContent = style.focus ?? 'Signature Mix';
+      tagCluster.appendChild(focusPill);
+
+      if (style.isCustom) {
+        const customBadge = document.createElement('span');
+        customBadge.className = 'style-custom-badge';
+        customBadge.textContent = 'Custom';
+        tagCluster.appendChild(customBadge);
+      }
+
+      topRow.appendChild(tagCluster);
+
+      button.appendChild(topRow);
+
+      const discipline = document.createElement('span');
+      discipline.className = 'style-meta';
+      discipline.textContent = style.discipline;
+      button.appendChild(discipline);
+
+      const headline = document.createElement('p');
+      headline.className = 'style-headline';
+      headline.textContent = style.headline;
+      button.appendChild(headline);
+
+      button.addEventListener('click', () => toggleStyleSelection(style.id));
+
+      fragment.appendChild(button);
+    });
+    styleContainer.appendChild(fragment);
+  }
+
+  function refreshStyleLibrary({ maintainSelection = true } = {}) {
+    styleLibraryData = [...baseStyleLibraryData, ...customStyleLibraryData];
+    if (!maintainSelection) {
+      selectedStyleIds.clear();
+    } else {
+      const preserved = new Set(selectedStyleIds);
+      selectedStyleIds.clear();
+      styleLibraryData.forEach((style) => {
+        if (preserved.has(style.id)) {
+          selectedStyleIds.add(style.id);
+        }
+      });
+    }
+    renderStyleLibrary(styleLibraryData);
+    syncStyleCardStates();
+  }
+
+  function renderCustomBuilderList(data, container, type) {
+    if (!container) return;
+    container.innerHTML = '';
+    const fragment = document.createDocumentFragment();
+    data.forEach((item) => {
+      const label = document.createElement('label');
+      label.className = 'builder-item';
+
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.value = item.id;
+      input.name = type === 'combo' ? 'customCombos' : 'customTechniques';
+      label.appendChild(input);
+
+      const textWrapper = document.createElement('div');
+      textWrapper.className = 'builder-item-body';
+
+      const title = document.createElement('span');
+      title.className = 'builder-title';
+      title.textContent = item.name;
+      textWrapper.appendChild(title);
+
+      const meta = document.createElement('span');
+      meta.className = 'builder-meta';
+      meta.textContent = `${type === 'combo' ? 'Combo' : 'Technique'} • ${item.category}`;
+      textWrapper.appendChild(meta);
+
+      if (item.description) {
+        const detail = document.createElement('span');
+        detail.className = 'builder-description';
+        detail.textContent = item.description;
+        textWrapper.appendChild(detail);
+      }
+
+      label.appendChild(textWrapper);
+      fragment.appendChild(label);
+    });
+    container.appendChild(fragment);
+  }
+
+  function handleCustomStyleSubmit(event) {
+    event.preventDefault();
+    if (!customStyleForm) return;
+
+    const formData = new FormData(customStyleForm);
+    const name = String(formData.get('customStyleName') ?? '').trim();
+    const discipline = String(formData.get('customStyleDiscipline') ?? '').trim();
+    const focus = String(formData.get('customStyleFocus') ?? '').trim();
+    const headline = String(formData.get('customStyleHeadline') ?? '').trim();
+    const summary = String(formData.get('customStyleSummary') ?? '').trim();
+    const coachingRaw = String(formData.get('customStyleCoaching') ?? '');
+    const combos = getCheckedValues(customComboList);
+    const techniques = getCheckedValues(customTechniqueList);
+
+    if (!name) {
+      showCustomStyleMessage('Give your style a name before saving.', true);
+      return;
+    }
+
+    if (combos.length === 0 && techniques.length === 0) {
+      showCustomStyleMessage('Select at least one combination or technique to store with the style.', true);
+      return;
+    }
+
+    const coaching = coachingRaw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    const newStyle = {
+      id: createUniqueStyleId(name),
+      name,
+      discipline: discipline || 'Custom Blend',
+      focus: focus || 'Personal Mix',
+      headline: headline || 'Your personalized round blueprint.',
+      summary:
+        summary ||
+        'Hand-picked moves saved from your builder so you can reload this flow in a single tap.',
+      combos,
+      techniques,
+      coaching,
+      isCustom: true,
+    };
+
+    customStyleLibraryData.push(newStyle);
+    persistCustomStyles();
+    refreshStyleLibrary({ maintainSelection: true });
+    selectedStyleIds.add(newStyle.id);
+    syncStyleCardStates();
+    updateSelectionSummary();
+    renderStyleInstructions();
+    focusStyleCard(newStyle.id);
+    resetCustomStyleForm();
+    showCustomStyleMessage(`Saved ${name} to your signature library.`, false);
+  }
+
+  function useCurrentSelectionsForCustomStyle() {
+    const { comboIds, techniqueIds } = collectSelectedMoveIds();
+    syncBuilderCheckboxes(customComboList, comboIds);
+    syncBuilderCheckboxes(customTechniqueList, techniqueIds);
+    if (comboIds.length === 0 && techniqueIds.length === 0) {
+      showCustomStyleMessage('Activate at least one style above to pull its moves into the builder.', true);
+    } else {
+      showCustomStyleMessage(
+        `Loaded ${comboIds.length} combos and ${techniqueIds.length} techniques from your active styles.`,
+        false,
+      );
+    }
+  }
+
+  function getCheckedValues(container) {
+    if (!container) return [];
+    return Array.from(container.querySelectorAll('input[type="checkbox"]:checked')).map((input) => input.value);
+  }
+
+  function syncBuilderCheckboxes(container, ids) {
+    if (!container) return;
+    const idSet = new Set(ids);
+    container.querySelectorAll('input[type="checkbox"]').forEach((input) => {
+      input.checked = idSet.has(input.value);
+    });
+  }
+
+  function resetCustomStyleForm() {
+    customStyleForm?.reset();
+    syncBuilderCheckboxes(customComboList, []);
+    syncBuilderCheckboxes(customTechniqueList, []);
+  }
+
+  function showCustomStyleMessage(message, isError) {
+    if (!customStyleMessage) return;
+    customStyleMessage.textContent = message;
+    customStyleMessage.classList.toggle('is-error', Boolean(isError));
+    if (message && customStyleToggle) {
+      toggleCustomStylePanel(true);
+    }
+  }
+
+  function createUniqueStyleId(name) {
+    const base = slugifyStyleName(name);
+    let candidate = base;
+    let counter = 2;
+    while (styleLibraryData.some((style) => style.id === candidate)) {
+      candidate = `${base}-${counter++}`;
+    }
+    return candidate;
+  }
+
+  function slugifyStyleName(value) {
+    const base = value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    return base || `custom-style-${Date.now()}`;
+  }
+
+  function persistCustomStyles() {
+    if (!supportsStorage) return;
+    try {
+      const payload = customStyleLibraryData.map(({ isCustom, ...style }) => style);
+      window.localStorage.setItem(CUSTOM_STYLE_STORAGE_KEY, JSON.stringify(payload));
+    } catch (error) {
+      console.warn('Unable to save custom styles', error);
+    }
+  }
+
+  function loadCustomStyles() {
+    if (!supportsStorage) return [];
+    try {
+      const raw = window.localStorage.getItem(CUSTOM_STYLE_STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return parsed
+        .filter((entry) => entry && typeof entry.id === 'string')
+        .map((entry) => ({ ...entry, isCustom: true }));
+    } catch (error) {
+      console.warn('Unable to load custom styles', error);
+      return [];
+    }
+  }
+
+  function toggleStyleSelection(styleId) {
+    if (selectedStyleIds.has(styleId)) {
+      selectedStyleIds.delete(styleId);
+    } else {
+      selectedStyleIds.add(styleId);
+    }
+    syncStyleCardStates();
+    updateSelectionSummary();
+    renderStyleInstructions();
+    if (selectedStyleIds.size > 0) {
+      callDisplay?.classList.remove('is-warning');
+    }
+  }
+
+  function clearAllStyles() {
+    if (selectedStyleIds.size === 0) {
+      return;
+    }
+    selectedStyleIds.clear();
+    syncStyleCardStates();
+    updateSelectionSummary();
+    renderStyleInstructions();
+    if (state.mode === 'idle') {
+      setActiveCallMessage('Select at least one signature style to begin.', '');
+      callDisplay?.classList.add('is-warning');
+    }
+  }
+
+  function syncStyleCardStates() {
+    if (!styleContainer) return;
+    styleContainer.querySelectorAll('.style-card').forEach((card) => {
+      const cardId = card.dataset.styleId ?? '';
+      const isActive = selectedStyleIds.has(cardId);
+      card.classList.toggle('active', isActive);
+      card.setAttribute('aria-pressed', String(isActive));
+    });
+  }
+
+  function focusStyleCard(styleId) {
+    const card = styleContainer?.querySelector(`.style-card[data-style-id="${styleId}"]`);
+    if (card instanceof HTMLElement) {
+      card.focus({ preventScroll: true });
+      card.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    }
+  }
+
+  function getSelectedStyles() {
+    if (selectedStyleIds.size === 0) {
+      return [];
+    }
+    return styleLibraryData.filter((style) => selectedStyleIds.has(style.id));
+  }
+
+  function renderStyleInstructions() {
+    if (!styleInstructions) return;
+    const activeStyles = getSelectedStyles();
+    if (activeStyles.length === 0) {
+      styleInstructions.innerHTML = defaultStyleInstructions;
+      return;
+    }
+    if (activeStyles.length === 1) {
+      renderSingleStyleInstructions(activeStyles[0]);
+      return;
+    }
+    renderMultiStyleInstructions(activeStyles);
+  }
+
+  function renderSingleStyleInstructions(style) {
+    if (!styleInstructions) return;
+
+    styleInstructions.innerHTML = '';
+
+    const title = document.createElement('h4');
+    title.textContent = `${style.name} Playbook`;
+    styleInstructions.appendChild(title);
+
+    const summary = document.createElement('p');
+    summary.textContent = style.summary;
+    styleInstructions.appendChild(summary);
+
+    if (Array.isArray(style.coaching) && style.coaching.length > 0) {
+      const cornerHeading = document.createElement('p');
+      cornerHeading.className = 'style-subheading';
+      cornerHeading.textContent = 'Corner notes';
+      styleInstructions.appendChild(cornerHeading);
+
+      const list = document.createElement('ul');
+      list.className = 'style-coaching-list';
+      style.coaching.forEach((cue) => {
+        const li = document.createElement('li');
+        li.textContent = cue;
+        list.appendChild(li);
+      });
+      styleInstructions.appendChild(list);
+    }
+
+    const selectionGroups = document.createElement('div');
+    selectionGroups.className = 'style-selection-groups';
+    selectionGroups.appendChild(buildStyleChipGroup('Loaded combinations', style.combos, combinationMap));
+    selectionGroups.appendChild(buildStyleChipGroup('Loaded techniques', style.techniques, techniqueMap));
+    styleInstructions.appendChild(selectionGroups);
+
+    const metaRow = document.createElement('div');
+    metaRow.className = 'style-meta-row';
+    const disciplineTag = document.createElement('span');
+    disciplineTag.className = 'style-tag';
+    disciplineTag.textContent = style.discipline;
+    const focusTag = document.createElement('span');
+    focusTag.className = 'style-tag';
+    focusTag.textContent = style.focus;
+    metaRow.append(disciplineTag, focusTag);
+    styleInstructions.appendChild(metaRow);
+  }
+
+  function renderMultiStyleInstructions(styles) {
+    if (!styleInstructions) return;
+
+    styleInstructions.innerHTML = '';
+
+    const title = document.createElement('h4');
+    title.textContent = `${styles.length} styles fused`;
+    styleInstructions.appendChild(title);
+
+    const summary = document.createElement('p');
+    summary.textContent = 'Expect variety—each call blends moves from the styles you selected.';
+    styleInstructions.appendChild(summary);
+
+    const aggregate = collectSelectedMoveIds();
+    const aggregateRow = document.createElement('div');
+    aggregateRow.className = 'style-meta-row style-meta-row--aggregate';
+    const comboTag = document.createElement('span');
+    comboTag.className = 'style-tag';
+    comboTag.textContent = `${aggregate.comboIds.length} combos`;
+    const techniqueTag = document.createElement('span');
+    techniqueTag.className = 'style-tag';
+    techniqueTag.textContent = `${aggregate.techniqueIds.length} techniques`;
+    aggregateRow.append(comboTag, techniqueTag);
+    styleInstructions.appendChild(aggregateRow);
+
+    const grid = document.createElement('div');
+    grid.className = 'style-multi-grid';
+
+    styles.forEach((style) => {
+      const card = document.createElement('article');
+      card.className = 'style-multi-card';
+
+      const heading = document.createElement('h5');
+      heading.textContent = style.name;
+      card.appendChild(heading);
+
+      if (style.summary) {
+        const styleSummary = document.createElement('p');
+        styleSummary.className = 'style-multi-summary';
+        styleSummary.textContent = style.summary;
+        card.appendChild(styleSummary);
+      }
+
+      if (Array.isArray(style.coaching) && style.coaching.length > 0) {
+        const cuesHeading = document.createElement('p');
+        cuesHeading.className = 'style-subheading';
+        cuesHeading.textContent = 'Corner notes';
+        card.appendChild(cuesHeading);
+
+        const list = document.createElement('ul');
+        list.className = 'style-coaching-list';
+        style.coaching.forEach((cue) => {
+          const li = document.createElement('li');
+          li.textContent = cue;
+          list.appendChild(li);
+        });
+        card.appendChild(list);
+      }
+
+      const selectionGroups = document.createElement('div');
+      selectionGroups.className = 'style-selection-groups';
+      selectionGroups.appendChild(buildStyleChipGroup('Combos', style.combos, combinationMap));
+      selectionGroups.appendChild(buildStyleChipGroup('Techniques', style.techniques, techniqueMap));
+      card.appendChild(selectionGroups);
+
+      const metaRow = document.createElement('div');
+      metaRow.className = 'style-meta-row';
+      const disciplineTag = document.createElement('span');
+      disciplineTag.className = 'style-tag';
+      disciplineTag.textContent = style.discipline;
+      const focusTag = document.createElement('span');
+      focusTag.className = 'style-tag';
+      focusTag.textContent = style.focus;
+      metaRow.append(disciplineTag, focusTag);
+      card.appendChild(metaRow);
+
+      grid.appendChild(card);
+    });
+
+    styleInstructions.appendChild(grid);
+  }
+
+  function buildStyleChipGroup(label, ids, sourceMap) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'style-chip-section';
+
+    const heading = document.createElement('span');
+    heading.className = 'style-selection-title';
+    heading.textContent = label;
+    wrapper.appendChild(heading);
+
+    const chipRow = document.createElement('div');
+    chipRow.className = 'style-chip-group';
+    ids.forEach((id) => {
+      const item = sourceMap.get(id);
+      if (!item) return;
+      const chip = document.createElement('span');
+      chip.className = 'style-chip';
+      chip.textContent = item.name;
+      chipRow.appendChild(chip);
+    });
+
+    if (!chipRow.childNodes.length) {
+      const empty = document.createElement('span');
+      empty.className = 'style-chip empty';
+      empty.textContent = 'None loaded';
+      chipRow.appendChild(empty);
+    }
+
+    wrapper.appendChild(chipRow);
+    return wrapper;
+  }
+
+  function collectSelectedMoveIds() {
+    const comboIds = new Set();
+    const techniqueIds = new Set();
+    getSelectedStyles().forEach((style) => {
+      style.combos.forEach((comboId) => comboIds.add(comboId));
+      style.techniques.forEach((techId) => techniqueIds.add(techId));
+    });
+    return {
+      comboIds: Array.from(comboIds),
+      techniqueIds: Array.from(techniqueIds),
+    };
+  }
+
+  function toggleCustomStylePanel(forceOpen) {
+    if (!customStyleToggle || !customStylePanel) return;
+    const expanded = customStyleToggle.getAttribute('aria-expanded') === 'true';
+    const nextState =
+      typeof forceOpen === 'boolean' ? forceOpen : !expanded;
+    customStyleToggle.setAttribute('aria-expanded', String(nextState));
+    customStyleToggle.classList.toggle('is-open', nextState);
+    customStylePanel.hidden = !nextState;
+    customStyleBuilder?.classList.toggle('is-open', nextState);
+  }
+
+  function buildStyleChipGroup(label, ids, sourceMap) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'style-chip-section';
+
+    const heading = document.createElement('span');
+    heading.className = 'style-selection-title';
+    heading.textContent = label;
+    wrapper.appendChild(heading);
+
+    const chipRow = document.createElement('div');
+    chipRow.className = 'style-chip-group';
+    ids.forEach((id) => {
+      const item = sourceMap.get(id);
+      if (!item) return;
+      const chip = document.createElement('span');
+      chip.className = 'style-chip';
+      chip.textContent = item.name;
+      chipRow.appendChild(chip);
+    });
+
+    if (!chipRow.childNodes.length) {
+      const empty = document.createElement('span');
+      empty.className = 'style-chip empty';
+      empty.textContent = 'None loaded';
+      chipRow.appendChild(empty);
+    }
+
+    wrapper.appendChild(chipRow);
+    return wrapper;
+  }
+
+  function startRound() {
+    const pool = buildSelectionPool();
+    if (pool.length === 0) {
+      showWarning('Select at least one signature style to begin.');
+      return;
+    }
+
+    const roundMinutes = clampToRange(roundLengthSelect?.value ?? '3', 1, 5);
+    roundLengthSelect.value = String(roundMinutes);
+    const callRate = clampToRange(callRateInput?.value ?? '10', 4, 30);
+    callRateInput.value = String(callRate);
+    const restSeconds = clampToRange(restLengthInput?.value ?? '45', 0, 180);
+    restLengthInput.value = String(restSeconds);
+
+    state.allowRepeats = Boolean(allowRepeatsCheckbox?.checked);
+    state.pool = pool;
+    state.availablePool = [...pool];
+    state.roundDurationMs = roundMinutes * 60000;
+    state.restDurationMs = restSeconds * 1000;
+    state.callIntervalMs = Math.max(1500, Math.round(60000 / callRate));
+    state.mode = 'round';
+    state.isPaused = false;
+    state.remainingMs = state.roundDurationMs;
+    state.phaseEndsAt = Date.now() + state.roundDurationMs;
+
+    clearHistory();
+    stopIntervals();
+    pauseButton.textContent = 'Pause';
+    phaseIndicator.textContent = 'Round';
+    setActiveCallMessage('Round armed. First cue coming up...', '');
+    callDisplay?.classList.remove('is-warning');
+
+    startButton.disabled = true;
+    pauseButton.disabled = false;
+    resetButton.disabled = false;
+    nextButton.disabled = false;
+
+    updateTimerDisplay();
+    state.timerInterval = window.setInterval(tick, 100);
+    tick();
+    deliverCall(true);
+    state.callInterval = window.setInterval(() => {
+      deliverCall();
+    }, state.callIntervalMs);
+    playStartCue();
+  }
+
+  function togglePause() {
+    if (state.mode !== 'round' && state.mode !== 'rest') {
+      return;
+    }
+
+    if (!state.isPaused) {
+      state.isPaused = true;
+      pauseButton.textContent = 'Resume';
+      state.remainingMs = Math.max(0, state.phaseEndsAt - Date.now());
+      if (state.timerInterval) {
+        window.clearInterval(state.timerInterval);
+        state.timerInterval = null;
+      }
+      if (state.mode === 'round' && state.callInterval) {
+        window.clearInterval(state.callInterval);
+        state.callInterval = null;
+      }
+      if ('speechSynthesis' in window) {
+        window.speechSynthesis.cancel();
+      }
+    } else {
+      state.isPaused = false;
+      pauseButton.textContent = 'Pause';
+      state.phaseEndsAt = Date.now() + state.remainingMs;
+      state.timerInterval = window.setInterval(tick, 100);
+      tick();
+      if (state.mode === 'round') {
+        deliverCall(true);
+        state.callInterval = window.setInterval(() => {
+          deliverCall();
+        }, state.callIntervalMs);
+      }
+    }
+  }
+
+  function handleNextCall() {
+    if (state.mode !== 'round' || state.pool.length === 0) {
+      return;
+    }
+
+    const wasPaused = state.isPaused;
+    deliverCall(true);
+    if (!wasPaused) {
+      if (state.callInterval) {
+        window.clearInterval(state.callInterval);
+      }
+      state.callInterval = window.setInterval(() => {
+        deliverCall();
+      }, state.callIntervalMs);
+    }
+  }
+
+  function resetRound() {
+    stopIntervals();
+    state.mode = 'idle';
+    state.isPaused = false;
+    state.pool = [];
+    state.availablePool = [];
+    state.remainingMs = clampToRange(roundLengthSelect?.value ?? '3', 1, 5) * 60000;
+    phaseIndicator.textContent = 'Ready';
+    setActiveCallMessage('Select signature styles and press start.', '');
+    callDisplay?.classList.remove('is-warning');
+    updateTimerDisplay();
+    if ('speechSynthesis' in window) {
+      window.speechSynthesis.cancel();
+    }
+
+    startButton.disabled = false;
+    pauseButton.disabled = true;
+    pauseButton.textContent = 'Pause';
+    resetButton.disabled = true;
+    nextButton.disabled = true;
+
+    clearHistory();
+  }
+
+  function buildSelectionPool() {
+    const pool = [];
+    const { comboIds, techniqueIds } = collectSelectedMoveIds();
+
+    comboIds.forEach((comboId) => {
+      const combo = combinationMap.get(comboId);
+      if (!combo) return;
+      pool.push(toCallEntry(combo, 'combo'));
+    });
+
+    techniqueIds.forEach((techId) => {
+      const technique = techniqueMap.get(techId);
+      if (!technique) return;
+      pool.push(toCallEntry(technique, 'technique'));
+    });
+
+    return pool;
+  }
+
+  function toCallEntry(item, type) {
+    const sequence = 'sequence' in item && Array.isArray(item.sequence) ? item.sequence : [item.name];
+    const label = sequence.join(' → ');
+    const speakText = sequence.join(', ');
+    return {
+      id: item.id,
+      label,
+      sequence,
+      meta: `${type === 'combo' ? 'Combo' : 'Technique'} • ${item.category}`,
+      speakText,
+      type,
+    };
+  }
+
+  function deliverCall(force = false) {
+    if (state.mode !== 'round' || state.pool.length === 0) {
+      return;
+    }
+
+    if (state.isPaused && !force) {
+      return;
+    }
+
+    const entry = pickNextEntry();
+    if (!entry) {
+      return;
+    }
+
+    setActiveCallMessage(entry.label, entry.meta);
+    addToHistory(entry);
+    speakCall(entry);
+  }
+
+  function pickNextEntry() {
+    if (state.pool.length === 0) {
+      return null;
+    }
+
+    if (state.allowRepeats) {
+      const index = Math.floor(Math.random() * state.pool.length);
+      return state.pool[index];
+    }
+
+    if (state.availablePool.length === 0) {
+      state.availablePool = [...state.pool];
+    }
+
+    const index = Math.floor(Math.random() * state.availablePool.length);
+    const [entry] = state.availablePool.splice(index, 1);
+    return entry ?? null;
+  }
+
+  function tick() {
+    state.remainingMs = Math.max(0, state.phaseEndsAt - Date.now());
+    updateTimerDisplay();
+    if (state.remainingMs <= 0) {
+      if (state.timerInterval) {
+        window.clearInterval(state.timerInterval);
+        state.timerInterval = null;
+      }
+      onPhaseComplete();
+    }
+  }
+
+  function onPhaseComplete() {
+    if (state.mode === 'round') {
+      if (state.callInterval) {
+        window.clearInterval(state.callInterval);
+        state.callInterval = null;
+      }
+      playEndCue();
+      if (state.restDurationMs > 0) {
+        startRestPhase();
+      } else {
+        completeSession();
+      }
+    } else if (state.mode === 'rest') {
+      playStartCue();
+      completeSession();
+    }
+  }
+
+  function startRestPhase() {
+    state.mode = 'rest';
+    state.isPaused = false;
+    pauseButton.disabled = false;
+    pauseButton.textContent = 'Pause';
+    nextButton.disabled = true;
+    phaseIndicator.textContent = 'Rest';
+    state.remainingMs = state.restDurationMs;
+    state.phaseEndsAt = Date.now() + state.restDurationMs;
+    setActiveCallMessage('Recover, breathe, and get ready for the next bell.', 'Rest interval');
+    callDisplay?.classList.remove('is-warning');
+    state.timerInterval = window.setInterval(tick, 100);
+    tick();
+  }
+
+  function completeSession() {
+    stopIntervals();
+    state.mode = 'complete';
+    state.isPaused = false;
+    state.remainingMs = 0;
+    updateTimerDisplay();
+    startButton.disabled = false;
+    pauseButton.disabled = true;
+    pauseButton.textContent = 'Pause';
+    nextButton.disabled = true;
+    resetButton.disabled = false;
+    setActiveCallMessage('Round complete. Adjust your selections and tap start when ready.', '');
+    callDisplay?.classList.remove('is-warning');
+  }
+
+  function stopIntervals() {
+    if (state.timerInterval) {
+      window.clearInterval(state.timerInterval);
+      state.timerInterval = null;
+    }
+    if (state.callInterval) {
+      window.clearInterval(state.callInterval);
+      state.callInterval = null;
+    }
+  }
+
+  function addToHistory(entry) {
+    if (!callHistoryList) {
+      return;
+    }
+
+    const item = document.createElement('li');
+    item.className = 'history-item';
+
+    const head = document.createElement('div');
+    head.className = 'call-head';
+
+    const name = document.createElement('span');
+    name.className = 'call-name';
+    name.textContent = entry.label;
+    head.appendChild(name);
+
+    const stamp = document.createElement('span');
+    stamp.className = 'call-stamp';
+    const elapsed = Math.max(0, state.roundDurationMs - state.remainingMs);
+    stamp.textContent = formatStamp(elapsed);
+    head.appendChild(stamp);
+
+    const meta = document.createElement('div');
+    meta.className = 'call-meta';
+    meta.textContent = entry.meta;
+
+    item.append(head, meta);
+    callHistoryList.appendChild(item);
+
+    if (callHistoryList.children.length > 40) {
+      callHistoryList.removeChild(callHistoryList.firstElementChild);
+    }
+
+    callHistoryList.scrollTop = callHistoryList.scrollHeight;
+  }
+
+  function clearHistory() {
+    if (callHistoryList) {
+      callHistoryList.innerHTML = '';
+      callHistoryList.scrollTop = 0;
+    }
+  }
+
+  function updateSelectionSummary() {
+    const { comboIds, techniqueIds } = collectSelectedMoveIds();
+    if (comboCount) {
+      comboCount.textContent = String(comboIds.length);
+    }
+    if (techniqueCount) {
+      techniqueCount.textContent = String(techniqueIds.length);
+    }
+    if (comboIds.length + techniqueIds.length > 0) {
+      callDisplay?.classList.remove('is-warning');
+    } else if (state.mode === 'idle') {
+      setActiveCallMessage('Select at least one signature style to begin.', '');
+      callDisplay?.classList.add('is-warning');
+    }
+  }
+
+  function updateTimerDisplay() {
+    if (!timerDisplay) {
+      return;
+    }
+    timerDisplay.textContent = formatClock(state.remainingMs);
+  }
+
+  function setActiveCallMessage(sequence, tags) {
+    if (callSequence) {
+      callSequence.textContent = sequence;
+    }
+    if (callTags) {
+      callTags.textContent = tags;
+    }
+    callDisplay?.classList.remove('is-warning');
+  }
+
+  function showWarning(message) {
+    setActiveCallMessage(message, '');
+    callDisplay?.classList.add('is-warning');
+  }
+
+  function speakCall(entry) {
+    if (!('speechSynthesis' in window)) {
+      return;
+    }
+    try {
+      window.speechSynthesis.cancel();
+      const utterance = new SpeechSynthesisUtterance(entry.speakText);
+      utterance.rate = 1.05;
+      utterance.pitch = 1;
+      utterance.volume = 1;
+      window.speechSynthesis.speak(utterance);
+    } catch (error) {
+      // No-op if speech synthesis is unavailable
+    }
+  }
+
+  function clampToRange(value, min, max) {
+    const numeric = Math.round(Number(value));
+    if (Number.isNaN(numeric)) {
+      return min;
+    }
+    return Math.min(max, Math.max(min, numeric));
+  }
+
+  function formatClock(ms) {
+    const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  function formatStamp(ms) {
+    const totalSeconds = Math.max(0, Math.round(ms / 1000));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  function initializeTimerDisplay() {
+    state.remainingMs = clampToRange(roundLengthSelect?.value ?? '3', 1, 5) * 60000;
+    updateTimerDisplay();
+  }
+
+  function playStartCue() {
+    playTone(880, 0.25);
+    window.setTimeout(() => {
+      playTone(1180, 0.2);
+    }, 140);
+  }
+
+  function playEndCue() {
+    playTone(540, 0.3);
+    window.setTimeout(() => {
+      playTone(420, 0.35);
+    }, 160);
+  }
+
+  function playTone(frequency, duration = 0.3) {
+    const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+    if (!AudioContextCtor) {
+      return;
+    }
+    if (!audioContext) {
+      audioContext = new AudioContextCtor();
+    }
+    if (audioContext.state === 'suspended') {
+      audioContext.resume().catch(() => {});
+    }
+
+    const oscillator = audioContext.createOscillator();
+    const gain = audioContext.createGain();
+    oscillator.type = 'sine';
+    oscillator.frequency.value = frequency;
+    gain.gain.value = 0.06;
+
+    oscillator.connect(gain);
+    gain.connect(audioContext.destination);
+
+    const now = audioContext.currentTime;
+    oscillator.start(now);
+    gain.gain.setValueAtTime(0.06, now);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+    oscillator.stop(now + duration + 0.05);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,664 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bagwork Buddy App</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Archivo:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header" id="top">
+        <nav class="nav">
+          <a href="#top" class="logo">Bagwork Buddy</a>
+          <button class="nav-toggle" aria-label="Open navigation">
+            <span></span>
+            <span></span>
+          </button>
+          <ul class="nav-links">
+            <li><a href="#programs">Programs</a></li>
+            <li><a href="#schedule">Schedule</a></li>
+            <li><a href="#coaches">Coaches</a></li>
+            <li><a href="#membership">Membership</a></li>
+            <li><a href="#download">Download</a></li>
+          </ul>
+          <a class="nav-cta" href="#download">Join Now</a>
+        </nav>
+        <section class="hero">
+          <div class="hero-copy">
+            <div class="eyebrow">Muay Thai & Functional Training</div>
+            <h1>Train like a champion. Recover like a pro.</h1>
+            <p>
+              The Bagwork Buddy app fuses striking, conditioning, and
+              recovery into one elevated experience. Stream on-demand classes,
+              book live sessions, and track your fight-ready progress from
+              anywhere.
+            </p>
+            <div class="hero-actions">
+              <a class="btn primary" href="#download">Start Free Trial</a>
+              <a class="btn ghost" href="#programs">Explore Programs</a>
+            </div>
+            <dl class="hero-stats">
+              <div>
+                <dt>60+</dt>
+                <dd>On-demand combinations</dd>
+              </div>
+              <div>
+                <dt>5+</dt>
+                <dd>Elite coaches worldwide</dd>
+              </div>
+              <div>
+                <dt>4.9★</dt>
+                <dd>Member satisfaction</dd>
+              </div>
+            </dl>
+          </div>
+          <div class="hero-media" aria-hidden="true">
+            <div class="phone-frame">
+              <div class="status-bar"></div>
+              <div class="screen">
+                <div class="screen-card">
+                  <span class="tag">Live now</span>
+                  <h3>Southpaw Striking Lab</h3>
+                  <p>Coach Ploy • Intermediate • 45 min</p>
+                </div>
+                <div class="screen-card">
+                  <span class="tag recovery">Recovery</span>
+                  <h3>Ice Bath Breathwork</h3>
+                  <p>Coach Marcus • Restore • 15 min</p>
+                </div>
+                <div class="screen-card">
+                  <span class="tag">Conditioning</span>
+                  <h3>Heavy Bag Burn</h3>
+                  <p>Coach Malik • Power • 30 min</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </header>
+      <main>
+        <section class="section training-lab" id="training">
+          <div class="section-header">
+            <span class="eyebrow">Training Lab</span>
+            <h2>Build your custom round.</h2>
+            <p>
+              Choose signature Bagwork Buddy combinations or single techniques
+              and let the app pace your round with audible cues and a polished, ringside-inspired interface.
+            </p>
+          </div>
+          <div class="training-grid">
+            <div class="round-console">
+              <div class="round-status">
+                <div class="phase-indicator" id="roundPhase">Ready</div>
+                <div class="timer-display" id="timerDisplay" aria-live="polite">03:00</div>
+              </div>
+              <div class="call-display" aria-live="assertive">
+                <div class="call-sequence" id="activeCall">
+                  Select signature styles and press start.
+                </div>
+                <div class="call-tags" id="activeTags"></div>
+              </div>
+              <form class="round-settings" id="roundSettings">
+                <div class="field">
+                  <label for="roundLength">Round length</label>
+                  <select id="roundLength" name="roundLength">
+                    <option value="1">1 minute</option>
+                    <option value="2">2 minutes</option>
+                    <option value="3" selected>3 minutes</option>
+                    <option value="4">4 minutes</option>
+                    <option value="5">5 minutes</option>
+                  </select>
+                </div>
+                <div class="field">
+                  <label for="callRate">Calls per minute</label>
+                  <input
+                    type="number"
+                    id="callRate"
+                    name="callRate"
+                    min="4"
+                    max="30"
+                    step="1"
+                    value="10"
+                  />
+                  <p class="field-hint">How many cues you want announced each minute.</p>
+                </div>
+                <div class="field">
+                  <label for="restLength">Rest (seconds)</label>
+                  <input
+                    type="number"
+                    id="restLength"
+                    name="restLength"
+                    min="0"
+                    max="180"
+                    step="5"
+                    value="45"
+                  />
+                </div>
+                <div class="field checkbox-field">
+                  <input type="checkbox" id="allowRepeats" name="allowRepeats" checked />
+                  <label for="allowRepeats">Allow repeated calls</label>
+                </div>
+              </form>
+              <div class="round-controls">
+                <button class="btn primary" type="button" id="startRound">Start Round</button>
+                <button class="btn ghost" type="button" id="pauseRound" disabled>Pause</button>
+                <button class="btn ghost" type="button" id="resetRound" disabled>Reset</button>
+                <button class="btn ghost" type="button" id="nextCall" disabled>Next Call</button>
+              </div>
+              <div class="selection-summary">
+                <div>
+                  <strong id="comboCount">0</strong>
+                  <span>Combos loaded</span>
+                </div>
+                <div>
+                  <strong id="techniqueCount">0</strong>
+                  <span>Techniques loaded</span>
+                </div>
+              </div>
+              <div class="call-history">
+                <div class="history-header">
+                  <h3>Round log</h3>
+                  <button type="button" class="link-button" id="clearHistory">Clear</button>
+                </div>
+                <ol id="callHistory" class="history-list" aria-live="polite"></ol>
+              </div>
+            </div>
+            <div class="library-pane">
+              <div class="library-section style-library">
+                <div class="library-heading">
+                  <h3 id="styleLibraryLabel">Signature Style Libraries</h3>
+                </div>
+                <p class="library-description">
+                  Pick a legendary striker to auto-load their go-to combinations, supporting techniques, and coaching notes.
+                </p>
+                <p class="library-hint">
+                  Tap multiple styles to blend their blueprints. We'll stack their moves together for the next round.
+                </p>
+                <div class="style-actions-row">
+                  <button type="button" id="clearStyles" class="link-button">Clear all styles</button>
+                </div>
+                <div class="style-grid-wrapper">
+                  <div
+                    class="style-card-grid"
+                    id="styleLibrary"
+                    role="list"
+                    aria-labelledby="styleLibraryLabel"
+                  ></div>
+                </div>
+                <div class="style-instructions" id="styleInstructions" aria-live="polite">
+                  <h4>Load a style to study the blueprint.</h4>
+                  <p>
+                    Choose a boxer above and we will preselect their signature work plus guided focus cues for your next round.
+                  </p>
+                </div>
+                <div class="custom-style-builder" id="customStyleBuilder">
+                  <button
+                    type="button"
+                    class="custom-style-toggle"
+                    id="customStyleToggle"
+                    aria-expanded="false"
+                    aria-controls="customStylePanel"
+                  >
+                    <div class="custom-style-toggle-copy">
+                      <span class="toggle-title">Add a signature style</span>
+                      <span class="toggle-subtitle">Design your own fighter blueprint</span>
+                    </div>
+                    <span class="custom-style-toggle-icon" aria-hidden="true"></span>
+                  </button>
+                  <div class="custom-style-panel" id="customStylePanel" hidden>
+                    <form id="customStyleForm" class="custom-style-form">
+                      <div class="custom-style-grid">
+                        <div class="field">
+                          <label for="customStyleName">Style name</label>
+                          <input type="text" id="customStyleName" name="customStyleName" required />
+                        </div>
+                        <div class="field">
+                          <label for="customStyleDiscipline">Discipline / vibe</label>
+                          <input
+                            type="text"
+                            id="customStyleDiscipline"
+                            name="customStyleDiscipline"
+                            placeholder="Hybrid Striking"
+                          />
+                        </div>
+                        <div class="field">
+                          <label for="customStyleFocus">Focus</label>
+                          <input type="text" id="customStyleFocus" name="customStyleFocus" placeholder="Tempo control" />
+                        </div>
+                        <div class="field">
+                          <label for="customStyleHeadline">Quick headline</label>
+                          <input
+                            type="text"
+                            id="customStyleHeadline"
+                            name="customStyleHeadline"
+                            placeholder="Describe the feel of the round"
+                          />
+                        </div>
+                        <div class="field field-span">
+                          <label for="customStyleSummary">Summary</label>
+                          <textarea
+                            id="customStyleSummary"
+                            name="customStyleSummary"
+                            rows="3"
+                            placeholder="What should the athlete focus on?"
+                          ></textarea>
+                        </div>
+                        <div class="field field-span">
+                          <label for="customStyleCoaching">Coaching cues (one per line)</label>
+                          <textarea
+                            id="customStyleCoaching"
+                            name="customStyleCoaching"
+                            rows="3"
+                            placeholder="Breathe through the nose before firing.&#10;Keep the stance springy after each kick."
+                          ></textarea>
+                        </div>
+                      </div>
+                      <p class="builder-hint">
+                        Pick which moves should load with this style. You can also pull from the styles you have active above.
+                      </p>
+                      <div class="builder-lists">
+                        <fieldset class="builder-fieldset">
+                          <legend>Combinations</legend>
+                          <div class="builder-list" id="customComboList"></div>
+                        </fieldset>
+                        <fieldset class="builder-fieldset">
+                          <legend>Techniques</legend>
+                          <div class="builder-list" id="customTechniqueList"></div>
+                        </fieldset>
+                      </div>
+                      <div class="builder-actions">
+                        <button type="button" class="link-button" id="customStyleUseSelection">Use active styles</button>
+                        <button type="submit" class="btn primary">Save style</button>
+                      </div>
+                    </form>
+                    <p class="builder-status" id="customStyleMessage" role="status" aria-live="polite"></p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+        <section class="section metrics" id="programs">
+          <div class="section-header">
+            <span class="eyebrow">App Highlights</span>
+            <h2>Sleek, immersive training sessions built for fighters.</h2>
+            <p>
+              Crafted with a modern training club aesthetic, the Bagwork Buddy
+              app keeps the focus on what matters: intelligent programming,
+              cinematic production, and next-level results.
+            </p>
+          </div>
+          <div class="metrics-grid">
+            <article class="metric">
+              <h3>Personalized Pathways</h3>
+              <p>
+                Adaptive programs progress with you—whether you are sharpening
+                fundamentals or prepping for the ring.
+              </p>
+            </article>
+            <article class="metric">
+              <h3>Hybrid Class Library</h3>
+              <p>
+                Muay Thai technique, strength conditioning, recovery protocols,
+                and mobility flows curated weekly.
+              </p>
+            </article>
+            <article class="metric">
+              <h3>Performance Analytics</h3>
+              <p>
+                Sync wearables, track rounds, and visualize pace and power with
+                real-time insights.
+              </p>
+            </article>
+            <article class="metric">
+              <h3>Community Corners</h3>
+              <p>
+                Join sparring labs, share highlights, and get accountability
+                from a global striking collective.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section class="section program-rail">
+          <div class="section-header">
+            <span class="eyebrow">Featured Collections</span>
+            <h2>Curated experiences for every fight camp.</h2>
+          </div>
+          <div class="program-cards">
+            <article class="program-card">
+              <div class="program-visual gradient-one"></div>
+              <div class="program-body">
+                <h3>Fight Camp 8-Week</h3>
+                <p>
+                  Phase-based conditioning with drills, sparring strategy, and
+                  taper weeks designed by pro fighters.
+                </p>
+                <ul>
+                  <li>6 days per week</li>
+                  <li>Progressive overload</li>
+                  <li>Corner coach notes</li>
+                </ul>
+              </div>
+            </article>
+            <article class="program-card">
+              <div class="program-visual gradient-two"></div>
+              <div class="program-body">
+                <h3>Technique Foundations</h3>
+                <p>
+                  Slow it down with cinematic breakdowns, footwork puzzles, and
+                  pad flows for every stance.
+                </p>
+                <ul>
+                  <li>Multi-angle replays</li>
+                  <li>Southpaw & orthodox</li>
+                  <li>Coach feedback portal</li>
+                </ul>
+              </div>
+            </article>
+            <article class="program-card">
+              <div class="program-visual gradient-three"></div>
+              <div class="program-body">
+                <h3>Recovery Rituals</h3>
+                <p>
+                  Contrast therapy, restorative mobility, and breathwork so you
+                  can hit every round fresh.
+                </p>
+                <ul>
+                  <li>Guided ice + sauna</li>
+                  <li>Sleep optimization</li>
+                  <li>Mindfulness soundscapes</li>
+                </ul>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="section schedule" id="schedule">
+          <div class="section-header">
+            <span class="eyebrow">Live Studio Schedule</span>
+            <h2>Drop into live energy from Bangkok to Brooklyn.</h2>
+          </div>
+          <div class="schedule-controls" role="tablist">
+            <button class="chip active" data-category="all">All</button>
+            <button class="chip" data-category="muay-thai">Muay Thai</button>
+            <button class="chip" data-category="strength">Strength</button>
+            <button class="chip" data-category="recovery">Recovery</button>
+          </div>
+          <div class="schedule-grid">
+            <article class="schedule-card" data-category="muay-thai">
+              <div>
+                <h3>Elbow Arsenal</h3>
+                <p>Coach Petch • Advanced • 60 min</p>
+              </div>
+              <span class="time">06:00 BKK</span>
+            </article>
+            <article class="schedule-card" data-category="strength">
+              <div>
+                <h3>Lower Body Ignition</h3>
+                <p>Coach Liv • Hybrid Strength • 45 min</p>
+              </div>
+              <span class="time">07:30 NYC</span>
+            </article>
+            <article class="schedule-card" data-category="muay-thai">
+              <div>
+                <h3>Clinch War Room</h3>
+                <p>Coach Dieselnoi • Clinch Tactics • 40 min</p>
+              </div>
+              <span class="time">09:00 BKK</span>
+            </article>
+            <article class="schedule-card" data-category="recovery">
+              <div>
+                <h3>Cold Plunge Breath</h3>
+                <p>Coach Marcus • Nervous System • 20 min</p>
+              </div>
+              <span class="time">11:00 LON</span>
+            </article>
+            <article class="schedule-card" data-category="strength">
+              <div>
+                <h3>Power Endurance Ladder</h3>
+                <p>Coach Nina • Kettlebell • 35 min</p>
+              </div>
+              <span class="time">18:30 NYC</span>
+            </article>
+            <article class="schedule-card" data-category="muay-thai">
+              <div>
+                <h3>Southpaw Playbook</h3>
+                <p>Coach Andre • Southpaw Flow • 30 min</p>
+              </div>
+              <span class="time">20:00 LAX</span>
+            </article>
+          </div>
+        </section>
+
+        <section class="section coaches" id="coaches">
+          <div class="section-header">
+            <span class="eyebrow">Elite Corners</span>
+            <h2>Coaches who have walked the walk.</h2>
+          </div>
+          <div class="coach-grid">
+            <article class="coach-card">
+              <div class="coach-portrait portrait-one"></div>
+              <div class="coach-body">
+                <h3>Coach Ploy</h3>
+                <p>3x Lumpinee Champ • Southpaw Specialist</p>
+                <ul>
+                  <li>Signature: Counter striking IQ</li>
+                  <li>Focus: Ringcraft & timing</li>
+                </ul>
+              </div>
+            </article>
+            <article class="coach-card">
+              <div class="coach-portrait portrait-two"></div>
+              <div class="coach-body">
+                <h3>Coach Marcus</h3>
+                <p>Performance Therapist • Breathwork Guide</p>
+                <ul>
+                  <li>Signature: Cold exposure pairing</li>
+                  <li>Focus: Nervous system mastery</li>
+                </ul>
+              </div>
+            </article>
+            <article class="coach-card">
+              <div class="coach-portrait portrait-three"></div>
+              <div class="coach-body">
+                <h3>Coach Liv</h3>
+                <p>Strength Coach • Combat Conditioning</p>
+                <ul>
+                  <li>Signature: Hybrid power circuits</li>
+                  <li>Focus: Force production</li>
+                </ul>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="section membership" id="membership">
+          <div class="section-header">
+            <span class="eyebrow">Memberships</span>
+            <h2>Choose your corner and go all in.</h2>
+          </div>
+          <div class="membership-grid">
+            <article class="plan">
+              <div class="plan-badge">Most Popular</div>
+              <h3>All Access Digital</h3>
+              <p class="price"><span>$29</span>/mo</p>
+              <ul>
+                <li>Unlimited on-demand library</li>
+                <li>Daily live class access</li>
+                <li>Performance analytics dashboard</li>
+                <li>Community sparring labs</li>
+              </ul>
+              <a class="btn primary" href="#download">Start 7-Day Trial</a>
+            </article>
+            <article class="plan">
+              <h3>Hybrid Studio</h3>
+              <p class="price"><span>$79</span>/mo</p>
+              <ul>
+                <li>Everything in Digital</li>
+                <li>Weekly in-person small groups</li>
+                <li>Quarterly skill assessments</li>
+                <li>VIP fight night events</li>
+              </ul>
+              <a class="btn ghost" href="#download">Request Invite</a>
+            </article>
+            <article class="plan">
+              <h3>Pro Corner</h3>
+              <p class="price"><span>$199</span>/mo</p>
+              <ul>
+                <li>Hybrid Studio benefits</li>
+                <li>1:1 coaching + program design</li>
+                <li>Recovery lab access</li>
+                <li>Camp nutrition consults</li>
+              </ul>
+              <a class="btn ghost" href="#download">Talk to a Coach</a>
+            </article>
+          </div>
+        </section>
+
+        <section class="section experience" id="download">
+          <div class="experience-shell">
+            <div class="experience-copy">
+              <span class="eyebrow">Download</span>
+              <h2>The fight studio in your pocket.</h2>
+              <p>
+                Stream cinematic classes, book live sessions, and sync your
+                metrics in a frictionless interface designed for night mode.
+                Works beautifully on iOS, Android, tablet, and web.
+              </p>
+              <div class="store-buttons">
+                <a class="store" href="#">
+                  <span class="icon" aria-hidden="true"></span>
+                  <span>
+                    <small>Download on the</small>
+                    <strong>App Store</strong>
+                  </span>
+                </a>
+                <a class="store" href="#">
+                  <span class="icon" aria-hidden="true">▶</span>
+                  <span>
+                    <small>GET IT ON</small>
+                    <strong>Google Play</strong>
+                  </span>
+                </a>
+              </div>
+            </div>
+            <div class="experience-media">
+              <div class="tablet-frame">
+                <div class="tablet-screen">
+                  <div class="tablet-card">
+                    <h3>Striking Focus</h3>
+                    <p>Rounds logged this week</p>
+                    <div class="progress">
+                      <div class="progress-bar"></div>
+                    </div>
+                    <ul>
+                      <li>Bag Rounds <span>18</span></li>
+                      <li>Pad Rounds <span>12</span></li>
+                      <li>Sparring <span>6</span></li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="section testimonials">
+          <div class="section-header">
+            <span class="eyebrow">Community Voices</span>
+            <h2>What Bagwork Buddy members are saying.</h2>
+          </div>
+          <div class="testimonial-carousel" aria-live="polite">
+            <button class="carousel-control prev" aria-label="Previous story">
+              ←
+            </button>
+            <div class="testimonial-track">
+              <article class="testimonial active">
+                <p>
+                  “The production value feels like a premium fight camp.
+                  Drilling combinations with real-time cues has levelled up my
+                  timing fast.”
+                </p>
+                <div class="author">
+                  <span class="avatar">RA</span>
+                  <div>
+                    <strong>Rico A.</strong>
+                    <small>Amateur Middleweight</small>
+                  </div>
+                </div>
+              </article>
+              <article class="testimonial">
+                <p>
+                  “Having breathwork and recovery stacked next to the sparring
+                  schedule keeps my nervous system in check. I’ve never felt so
+                  prepared.”
+                </p>
+                <div class="author">
+                  <span class="avatar">DL</span>
+                  <div>
+                    <strong>Dana L.</strong>
+                    <small>Fight Night Host</small>
+                  </div>
+                </div>
+              </article>
+              <article class="testimonial">
+                <p>
+                  “The data tracking with my wearable gives me true feedback on
+                  power and volume. The community challenges are wild.”
+                </p>
+                <div class="author">
+                  <span class="avatar">KM</span>
+                  <div>
+                    <strong>Kai M.</strong>
+                    <small>Competitive Striker</small>
+                  </div>
+                </div>
+              </article>
+            </div>
+            <button class="carousel-control next" aria-label="Next story">
+              →
+            </button>
+          </div>
+        </section>
+      </main>
+      <footer class="footer">
+        <div class="footer-grid">
+          <div>
+            <a href="#top" class="logo">Bagwork Buddy</a>
+            <p>
+              Precision striking, intelligent recovery, and community-driven
+              accountability in one beautifully designed app.
+            </p>
+          </div>
+          <div>
+            <h4>Explore</h4>
+            <ul>
+              <li><a href="#programs">Programs</a></li>
+              <li><a href="#schedule">Live Schedule</a></li>
+              <li><a href="#coaches">Coaches</a></li>
+              <li><a href="#membership">Membership</a></li>
+            </ul>
+          </div>
+          <div>
+            <h4>Connect</h4>
+            <ul>
+              <li><a href="mailto:team@bagworkbuddy.app">Email</a></li>
+              <li><a href="#">Instagram</a></li>
+              <li><a href="#">YouTube</a></li>
+            </ul>
+          </div>
+        </div>
+        <p class="footer-note">© 2025 Bagwork Buddy. All rights reserved.</p>
+      </footer>
+    </div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1890 @@
+:root {
+  --bg: #05060a;
+  --surface: #0b0d13;
+  --surface-soft: rgba(18, 21, 30, 0.75);
+  --card: #131622;
+  --card-soft: rgba(24, 28, 40, 0.7);
+  --primary: #f6a821;
+  --primary-soft: rgba(246, 168, 33, 0.25);
+  --text: #f8f9fb;
+  --text-muted: rgba(228, 231, 242, 0.65);
+  --accent: linear-gradient(135deg, #f9d65c, #f27219);
+  --accent-two: linear-gradient(135deg, #58dbd4, #2a69f7);
+  --accent-three: linear-gradient(135deg, #f66d94, #b852fa);
+  --radius-lg: 32px;
+  --radius-md: 24px;
+  --radius-sm: 16px;
+  --shadow-lg: 0 40px 80px rgba(0, 0, 0, 0.45);
+  --shadow-md: 0 20px 40px rgba(0, 0, 0, 0.35);
+  --shadow-sm: 0 10px 30px rgba(0, 0, 0, 0.25);
+  --max-width: min(1180px, 92vw);
+  --checkbox-size: 20px;
+  font-size: 62.5%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top left, rgba(246, 168, 33, 0.15), transparent 45%),
+    radial-gradient(circle at 80% 20%, rgba(88, 219, 212, 0.15), transparent 50%),
+    var(--bg);
+  color: var(--text);
+  font-family: "Inter", "Archivo", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-size: 1.6rem;
+  line-height: 1.6;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-shell {
+  position: relative;
+  overflow: hidden;
+}
+
+.app-header {
+  padding: 2.4rem 0 6rem;
+  background: linear-gradient(180deg, rgba(12, 14, 20, 0.9), rgba(5, 6, 10, 0.96) 30%, var(--bg));
+}
+
+.nav {
+  width: var(--max-width);
+  margin: 0 auto 5.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2.4rem;
+}
+
+.logo {
+  font-family: "Archivo", "Inter", sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text);
+  font-size: 1.8rem;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 2.4rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-links a {
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  transition: color 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+  color: var(--text);
+}
+
+.nav-cta {
+  padding: 1.2rem 2.6rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #0b0d13;
+  font-weight: 600;
+  font-size: 1.4rem;
+  letter-spacing: 0.04em;
+  box-shadow: var(--shadow-sm);
+}
+
+.nav-toggle {
+  display: none;
+  background: transparent;
+  border: 0;
+  padding: 0.8rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 2.4rem;
+  height: 2px;
+  background: var(--text);
+  margin-bottom: 0.6rem;
+}
+
+.hero {
+  width: var(--max-width);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6rem;
+  align-items: center;
+}
+
+.hero-copy .eyebrow,
+.section-header .eyebrow {
+  display: inline-block;
+  font-size: 1.2rem;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: var(--primary);
+  margin-bottom: 1.6rem;
+}
+
+.hero h1 {
+  font-family: "Archivo", sans-serif;
+  font-size: clamp(4rem, 4vw + 2rem, 6.6rem);
+  line-height: 1.05;
+  margin: 0 0 2.4rem;
+}
+
+.hero p {
+  color: var(--text-muted);
+  max-width: 48ch;
+  margin-bottom: 3.2rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1.6rem;
+  margin-bottom: 3.6rem;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 1.4rem 2.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 1.3rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn.primary {
+  background: var(--accent);
+  color: #11131d;
+  box-shadow: var(--shadow-md);
+}
+
+.btn.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.btn.ghost {
+  background: transparent;
+  border: 1px solid rgba(248, 249, 251, 0.2);
+  color: var(--text);
+}
+
+.btn.ghost:hover {
+  background: rgba(248, 249, 251, 0.08);
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 2.4rem;
+  margin: 0;
+}
+
+.hero-stats dt {
+  font-family: "Archivo", sans-serif;
+  font-size: 3.2rem;
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+}
+
+.hero-stats dd {
+  margin: 0;
+  font-size: 1.3rem;
+  color: var(--text-muted);
+}
+
+.hero-media {
+  display: flex;
+  justify-content: center;
+}
+
+.phone-frame {
+  width: clamp(280px, 35vw, 340px);
+  height: clamp(580px, 70vh, 680px);
+  background: linear-gradient(180deg, rgba(248, 249, 251, 0.1), rgba(15, 17, 24, 0.8));
+  border-radius: 42px;
+  padding: 2.4rem 1.8rem;
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  overflow: hidden;
+}
+
+.status-bar {
+  width: 60%;
+  height: 6px;
+  background: rgba(248, 249, 251, 0.4);
+  border-radius: 999px;
+  margin: 0 auto 2.4rem;
+}
+
+.screen {
+  background: rgba(10, 12, 18, 0.85);
+  border-radius: 28px;
+  padding: 2rem 1.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+  height: 100%;
+}
+
+.screen-card {
+  background: rgba(18, 22, 34, 0.9);
+  border-radius: 20px;
+  padding: 1.8rem;
+  position: relative;
+  box-shadow: var(--shadow-sm);
+  border: 1px solid rgba(248, 249, 251, 0.05);
+}
+
+.screen-card h3 {
+  margin: 0 0 0.8rem;
+  font-size: 1.7rem;
+}
+
+.screen-card p {
+  margin: 0;
+  font-size: 1.3rem;
+  color: var(--text-muted);
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 1.2rem;
+  border-radius: 999px;
+  font-size: 1.1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: var(--primary-soft);
+  color: var(--primary);
+  margin-bottom: 1.2rem;
+}
+
+.tag.recovery {
+  background: rgba(88, 219, 212, 0.2);
+  color: #58dbd4;
+}
+
+main {
+  padding: 6rem 0 8rem;
+  background: linear-gradient(180deg, var(--bg), rgba(6, 7, 10, 0.95));
+}
+
+.section {
+  width: var(--max-width);
+  margin: 0 auto;
+  padding: 6rem 0;
+}
+
+.section-header {
+  max-width: 70ch;
+  margin-bottom: 3.6rem;
+}
+
+.section-header h2 {
+  margin: 0 0 1.6rem;
+  font-family: "Archivo", sans-serif;
+  font-size: clamp(3.2rem, 3.2vw + 1rem, 4.6rem);
+  line-height: 1.1;
+}
+
+.section-header p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2.4rem;
+}
+
+.metric {
+  background: rgba(16, 19, 28, 0.7);
+  border: 1px solid rgba(248, 249, 251, 0.05);
+  padding: 2.8rem;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.metric h3 {
+  margin-top: 0;
+  margin-bottom: 1.2rem;
+  font-size: 1.9rem;
+  font-family: "Archivo", sans-serif;
+}
+
+.metric p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.program-rail {
+  position: relative;
+}
+
+.program-rail::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(88, 219, 212, 0.18), transparent 45%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.program-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2.8rem;
+}
+
+.program-card {
+  background: rgba(16, 19, 28, 0.78);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid rgba(248, 249, 251, 0.04);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+}
+
+.program-visual {
+  height: 220px;
+}
+
+.gradient-one {
+  background: radial-gradient(circle at 20% 20%, rgba(246, 168, 33, 0.55), transparent 60%),
+    var(--accent);
+}
+
+.gradient-two {
+  background: radial-gradient(circle at 80% 20%, rgba(42, 105, 247, 0.55), transparent 60%),
+    var(--accent-two);
+}
+
+.gradient-three {
+  background: radial-gradient(circle at 20% 80%, rgba(184, 82, 250, 0.55), transparent 60%),
+    var(--accent-three);
+}
+
+.program-body {
+  padding: 2.8rem;
+}
+
+.program-body h3 {
+  margin: 0 0 1.2rem;
+  font-family: "Archivo", sans-serif;
+  font-size: 2.2rem;
+}
+
+.program-body p {
+  margin: 0 0 2rem;
+  color: var(--text-muted);
+}
+
+.program-body ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+  font-size: 1.4rem;
+  color: rgba(248, 249, 251, 0.85);
+}
+
+.schedule {
+  background: rgba(12, 14, 20, 0.6);
+  border-radius: var(--radius-lg);
+  padding: 6rem 4rem;
+  border: 1px solid rgba(248, 249, 251, 0.04);
+  box-shadow: var(--shadow-lg);
+}
+
+.schedule-controls {
+  display: flex;
+  gap: 1.2rem;
+  margin-bottom: 3rem;
+  flex-wrap: wrap;
+}
+
+.chip {
+  border: 0;
+  background: rgba(248, 249, 251, 0.06);
+  color: var(--text-muted);
+  border-radius: 999px;
+  padding: 0.8rem 1.8rem;
+  font-size: 1.3rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.chip.active,
+.chip:hover {
+  background: var(--primary-soft);
+  color: var(--primary);
+  transform: translateY(-1px);
+}
+
+.schedule-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+}
+
+.schedule-card {
+  background: rgba(16, 19, 28, 0.75);
+  border-radius: var(--radius-md);
+  padding: 2.4rem;
+  border: 1px solid rgba(248, 249, 251, 0.05);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.4rem;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.schedule-card:hover {
+  transform: translateY(-4px);
+  background: rgba(18, 22, 34, 0.9);
+}
+
+.schedule-card h3 {
+  margin: 0 0 0.6rem;
+  font-size: 1.8rem;
+}
+
+.schedule-card p {
+  margin: 0;
+  font-size: 1.3rem;
+  color: var(--text-muted);
+}
+
+.time {
+  font-family: "Archivo", sans-serif;
+  font-size: 1.4rem;
+  color: var(--primary);
+}
+
+.coach-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2.6rem;
+}
+
+.coach-card {
+  background: rgba(16, 19, 28, 0.76);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid rgba(248, 249, 251, 0.05);
+  box-shadow: var(--shadow-md);
+}
+
+.coach-portrait {
+  height: 220px;
+  background-size: cover;
+  background-position: center;
+  filter: grayscale(0.15) contrast(1.1);
+}
+
+.portrait-one {
+  background-image: linear-gradient(180deg, rgba(5, 6, 10, 0.3), rgba(5, 6, 10, 0.8)),
+    radial-gradient(circle at 20% 20%, rgba(246, 168, 33, 0.4), transparent 60%),
+    url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"><rect width="400" height="400" fill="%2305060a"/><path d="M140 60h120v20H140zM80 120h240v24H80zM110 190h180v24H110zM150 260h100v24H150z" fill="%23f6a821" opacity="0.4"/></svg>');
+}
+
+.portrait-two {
+  background-image: linear-gradient(180deg, rgba(5, 6, 10, 0.3), rgba(5, 6, 10, 0.8)),
+    radial-gradient(circle at 80% 20%, rgba(88, 219, 212, 0.4), transparent 60%),
+    url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"><rect width="400" height="400" fill="%2305060a"/><circle cx="200" cy="200" r="120" fill="none" stroke="%2358dbd4" stroke-width="24" opacity="0.4"/></svg>');
+}
+
+.portrait-three {
+  background-image: linear-gradient(180deg, rgba(5, 6, 10, 0.3), rgba(5, 6, 10, 0.8)),
+    radial-gradient(circle at 20% 80%, rgba(184, 82, 250, 0.4), transparent 60%),
+    url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"><rect width="400" height="400" fill="%2305060a"/><path d="M120 280h160l-80-160z" fill="%23b852fa" opacity="0.45"/></svg>');
+}
+
+.coach-body {
+  padding: 2.6rem;
+}
+
+.coach-body h3 {
+  margin: 0 0 1rem;
+  font-size: 2rem;
+  font-family: "Archivo", sans-serif;
+}
+
+.coach-body p {
+  margin: 0 0 1.4rem;
+  color: var(--text-muted);
+}
+
+.coach-body ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.8rem;
+  font-size: 1.4rem;
+  color: rgba(248, 249, 251, 0.8);
+}
+
+.membership-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2.4rem;
+}
+
+.plan {
+  background: rgba(16, 19, 28, 0.82);
+  border-radius: var(--radius-lg);
+  padding: 3.2rem 2.8rem;
+  border: 1px solid rgba(248, 249, 251, 0.05);
+  box-shadow: var(--shadow-md);
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.plan-badge {
+  position: absolute;
+  top: 2.4rem;
+  right: 2.4rem;
+  background: var(--primary);
+  color: #0b0d13;
+  font-size: 1.1rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.plan h3 {
+  margin: 0;
+  font-family: "Archivo", sans-serif;
+  font-size: 2.2rem;
+}
+
+.price {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 1.4rem;
+}
+
+.price span {
+  font-size: 3rem;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.plan ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1rem;
+  color: rgba(248, 249, 251, 0.75);
+  font-size: 1.4rem;
+}
+
+.plan .btn {
+  margin-top: auto;
+}
+
+.experience {
+  position: relative;
+  background: linear-gradient(135deg, rgba(246, 168, 33, 0.16), rgba(10, 12, 18, 0.9));
+  border-radius: var(--radius-lg);
+  padding: 6rem;
+  border: 1px solid rgba(248, 249, 251, 0.05);
+  box-shadow: var(--shadow-lg);
+}
+
+.experience-shell {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 4.4rem;
+  align-items: center;
+}
+
+.store-buttons {
+  display: flex;
+  gap: 1.6rem;
+  flex-wrap: wrap;
+}
+
+.store {
+  display: inline-flex;
+  align-items: center;
+  gap: 1.2rem;
+  background: rgba(5, 6, 10, 0.75);
+  border-radius: 18px;
+  padding: 1.2rem 1.8rem;
+  border: 1px solid rgba(248, 249, 251, 0.08);
+  font-weight: 500;
+}
+
+.store small {
+  display: block;
+  font-size: 1rem;
+  letter-spacing: 0.16em;
+}
+
+.store strong {
+  font-size: 1.6rem;
+}
+
+.store .icon {
+  font-size: 2.4rem;
+  line-height: 1;
+}
+
+.tablet-frame {
+  width: min(420px, 80vw);
+  aspect-ratio: 3 / 4;
+  background: linear-gradient(160deg, rgba(88, 219, 212, 0.28), rgba(15, 17, 24, 0.95));
+  border-radius: 40px;
+  padding: 2.6rem;
+  box-shadow: var(--shadow-lg);
+}
+
+.tablet-screen {
+  background: rgba(7, 9, 14, 0.85);
+  border-radius: 28px;
+  height: 100%;
+  padding: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.tablet-card {
+  background: rgba(16, 19, 28, 0.9);
+  border-radius: 24px;
+  padding: 2.8rem;
+  width: 100%;
+  border: 1px solid rgba(248, 249, 251, 0.06);
+  display: grid;
+  gap: 1.6rem;
+}
+
+.tablet-card h3 {
+  margin: 0;
+  font-family: "Archivo", sans-serif;
+  font-size: 2.2rem;
+}
+
+.tablet-card p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.progress {
+  width: 100%;
+  height: 8px;
+  background: rgba(248, 249, 251, 0.08);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  width: 68%;
+  height: 100%;
+  background: var(--accent);
+}
+
+.tablet-card ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+  font-size: 1.4rem;
+  color: rgba(248, 249, 251, 0.75);
+}
+
+.tablet-card li {
+  display: flex;
+  justify-content: space-between;
+}
+
+.testimonial-carousel {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 2rem;
+  align-items: center;
+}
+
+.carousel-control {
+  background: rgba(248, 249, 251, 0.06);
+  border: 0;
+  color: var(--text);
+  font-size: 2.4rem;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.carousel-control:hover {
+  background: rgba(248, 249, 251, 0.12);
+  transform: translateY(-2px);
+}
+
+.testimonial-track {
+  position: relative;
+  overflow: hidden;
+}
+
+.testimonial {
+  display: none;
+  background: rgba(16, 19, 28, 0.78);
+  border-radius: var(--radius-lg);
+  padding: 3rem;
+  border: 1px solid rgba(248, 249, 251, 0.05);
+  box-shadow: var(--shadow-md);
+}
+
+.testimonial.active {
+  display: block;
+}
+
+.testimonial p {
+  margin: 0 0 2rem;
+  color: var(--text-muted);
+  font-size: 1.5rem;
+}
+
+.author {
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+}
+
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--accent);
+  color: #0b0d13;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  letter-spacing: 0.08em;
+}
+
+.footer {
+  padding: 6rem 0;
+  background: rgba(5, 6, 10, 0.95);
+  border-top: 1px solid rgba(248, 249, 251, 0.06);
+}
+
+.footer-grid {
+  width: var(--max-width);
+  margin: 0 auto 3.2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2.4rem;
+}
+
+.footer p {
+  color: var(--text-muted);
+  margin: 1.2rem 0 0;
+}
+
+.footer h4 {
+  margin: 0 0 1rem;
+  font-family: "Archivo", sans-serif;
+}
+
+.footer ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.8rem;
+  color: var(--text-muted);
+}
+
+.footer-note {
+  text-align: center;
+  margin: 0;
+  color: rgba(248, 249, 251, 0.5);
+  font-size: 1.2rem;
+}
+
+/* Responsive */
+@media (max-width: 960px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-media {
+    order: -1;
+  }
+
+  .nav-links,
+  .nav-cta {
+    display: none;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .nav.open .nav-links {
+    position: absolute;
+    inset: 72px 16px auto;
+    display: grid;
+    gap: 1.6rem;
+    background: rgba(5, 6, 10, 0.95);
+    border: 1px solid rgba(248, 249, 251, 0.06);
+    border-radius: 24px;
+    padding: 2.4rem;
+    box-shadow: var(--shadow-lg);
+  }
+
+  .nav.open .nav-cta {
+    display: inline-flex;
+    position: absolute;
+    inset: 320px 32px auto auto;
+  }
+
+  .style-grid-wrapper {
+    aspect-ratio: auto;
+    max-height: none;
+  }
+
+  .style-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  body {
+    font-size: 1.5rem;
+  }
+
+  .hero {
+    gap: 4rem;
+  }
+
+  .schedule {
+    padding: 4.4rem 2.4rem;
+  }
+
+  .experience {
+    padding: 4.4rem 2.4rem;
+  }
+
+  .testimonial-carousel {
+    grid-template-columns: 1fr;
+  }
+
+  .carousel-control {
+    justify-self: center;
+  }
+}
+
+@media (max-width: 520px) {
+  .section {
+    padding: 4.4rem 0;
+  }
+
+  .hero-stats {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  }
+}
+.training-lab .section-header {
+  max-width: 72ch;
+  margin: 0 auto;
+}
+
+.training-grid {
+  margin-top: 4rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 3.2rem;
+  align-items: start;
+}
+
+.round-console {
+  position: relative;
+  background: linear-gradient(160deg, rgba(246, 168, 33, 0.08), rgba(8, 9, 14, 0.9));
+  border-radius: var(--radius-lg);
+  padding: 3.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.round-console::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(88, 219, 212, 0.22), transparent 50%);
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.round-status {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  margin-bottom: 2.4rem;
+}
+
+.phase-indicator {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 1.2rem;
+  color: var(--text-muted);
+}
+
+.timer-display {
+  font-family: "Archivo", "Inter", sans-serif;
+  font-size: clamp(4.2rem, 3vw + 2.4rem, 6.4rem);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-align: right;
+}
+
+.call-display {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 2.8rem;
+  padding: 2.4rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 18, 26, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  transition: border-color 0.3s ease, background 0.3s ease;
+}
+
+.call-display.is-warning {
+  border-color: rgba(246, 168, 33, 0.6);
+  background: rgba(61, 36, 6, 0.6);
+}
+
+.call-sequence {
+  font-size: clamp(2rem, 2vw + 1.4rem, 3rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  margin-bottom: 0.8rem;
+}
+
+.call-tags {
+  font-size: 1.3rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.round-settings {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  margin-bottom: 2.8rem;
+}
+
+.field label {
+  display: block;
+  font-weight: 600;
+  font-size: 1.4rem;
+  margin-bottom: 0.8rem;
+  letter-spacing: 0.04em;
+}
+
+.round-settings select,
+.round-settings input[type="number"] {
+  width: 100%;
+  padding: 1.2rem 1.4rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  font-size: 1.5rem;
+  font-family: inherit;
+}
+
+.round-settings select:focus,
+.round-settings input[type="number"]:focus {
+  outline: 2px solid rgba(246, 168, 33, 0.6);
+  outline-offset: 2px;
+  border-color: rgba(246, 168, 33, 0.8);
+}
+
+.field-hint {
+  margin: 0.8rem 0 0;
+  font-size: 1.3rem;
+  color: var(--text-muted);
+}
+
+.checkbox-field {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  padding: 1.2rem 1.4rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.checkbox-field input[type="checkbox"] {
+  width: var(--checkbox-size);
+  height: var(--checkbox-size);
+  accent-color: var(--primary);
+}
+
+.checkbox-field label {
+  margin: 0;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+}
+
+.round-controls {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+  margin-bottom: 2.8rem;
+}
+
+.round-controls .btn {
+  flex: 1 1 160px;
+  justify-content: center;
+}
+
+.selection-summary {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.2rem;
+  padding: 1.8rem 2rem;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  margin-bottom: 3rem;
+}
+
+.selection-summary div {
+  text-align: center;
+}
+
+.selection-summary strong {
+  display: block;
+  font-size: 2.4rem;
+  font-family: "Archivo", "Inter", sans-serif;
+}
+
+.selection-summary span {
+  font-size: 1.3rem;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.call-history {
+  position: relative;
+  z-index: 1;
+}
+
+.history-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.6rem;
+  margin-bottom: 1.4rem;
+}
+
+.history-header h3 {
+  margin: 0;
+  font-size: 1.6rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 26rem;
+  overflow-y: auto;
+  display: grid;
+  gap: 1.2rem;
+}
+
+.history-item {
+  padding: 1.4rem 1.6rem;
+  border-radius: var(--radius-sm);
+  background: rgba(11, 13, 19, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.history-item .call-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.2rem;
+  margin-bottom: 0.6rem;
+}
+
+.history-item .call-name {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.history-item .call-stamp {
+  font-size: 1.2rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.history-item .call-meta {
+  font-size: 1.3rem;
+  color: var(--text-muted);
+}
+
+.link-button {
+  border: 0;
+  background: none;
+  color: var(--text-muted);
+  font-size: 1.2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.link-button:hover,
+.link-button:focus {
+  color: var(--text);
+}
+
+.library-pane {
+  display: grid;
+  gap: 2.4rem;
+}
+
+.library-section {
+  background: rgba(11, 13, 19, 0.82);
+  border-radius: var(--radius-lg);
+  padding: 2.8rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow-md);
+}
+
+.library-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1.6rem;
+  margin-bottom: 1.6rem;
+}
+
+.library-heading h3 {
+  margin: 0;
+  font-size: 1.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.library-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.library-description {
+  margin: 0 0 2rem;
+  font-size: 1.4rem;
+  color: var(--text-muted);
+}
+
+
+.library-hint {
+  font-size: 1.3rem;
+  color: var(--text-muted);
+  margin-bottom: 1.6rem;
+}
+
+.style-actions-row {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 1.2rem;
+}
+
+.style-grid-wrapper {
+  position: relative;
+  padding: 1.4rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(145deg, rgba(12, 15, 22, 0.82), rgba(20, 24, 34, 0.92));
+  aspect-ratio: 1 / 1;
+  max-height: 64rem;
+  overflow: hidden;
+  margin-bottom: 2.4rem;
+}
+
+.assistive-text {
+  font-size: 1.2rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.style-card-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-auto-rows: minmax(0, 1fr);
+  gap: 1.2rem;
+  height: 100%;
+  overflow-y: auto;
+  padding-right: 0.6rem;
+}
+
+.style-card-grid::-webkit-scrollbar {
+  width: 6px;
+}
+
+.style-card-grid::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+}
+
+.style-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.2rem;
+  padding: 1.8rem 2rem;
+  min-height: 15rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: radial-gradient(135% 140% at 0% 0%, rgba(255, 255, 255, 0.08) 0%, rgba(10, 12, 18, 0.82) 55%);
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  color: inherit;
+  text-align: left;
+  font: inherit;
+}
+
+.style-card:hover,
+.style-card:focus {
+  border-color: rgba(246, 168, 33, 0.4);
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+}
+
+.style-card.active {
+  border-color: rgba(255, 255, 255, 0.6);
+  box-shadow: 0 18px 44px rgba(246, 168, 33, 0.28);
+  background: linear-gradient(145deg, rgba(246, 168, 33, 0.28), rgba(122, 102, 255, 0.2));
+}
+
+.style-card:focus-visible {
+  outline: 2px solid rgba(246, 168, 33, 0.7);
+  outline-offset: 3px;
+}
+
+.style-card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.style-name {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 1.3rem;
+}
+
+.style-card-tags {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.style-pill {
+  font-size: 1.1rem;
+  padding: 0.3rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(246, 168, 33, 0.18);
+  color: var(--primary);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.style-custom-badge {
+  font-size: 1.1rem;
+  padding: 0.3rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.85);
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.style-meta {
+  font-size: 1.2rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.style-headline {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--text-muted);
+}
+
+.style-instructions {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  padding: 2.2rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+
+.custom-style-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  margin-top: 3.2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 12, 18, 0.68);
+  backdrop-filter: blur(16px);
+  overflow: hidden;
+}
+
+.custom-style-toggle {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.6rem;
+  width: 100%;
+  padding: 1.6rem 2rem;
+  border-radius: 0;
+  border: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(135deg, rgba(246, 168, 33, 0.18), rgba(255, 255, 255, 0.04));
+  color: inherit;
+  text-align: left;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  transition: border-color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease;
+}
+
+.custom-style-toggle:hover,
+.custom-style-toggle:focus-visible {
+  background: linear-gradient(135deg, rgba(246, 168, 33, 0.32), rgba(255, 255, 255, 0.08));
+  box-shadow: 0 16px 32px rgba(246, 168, 33, 0.12);
+}
+
+.custom-style-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(246, 168, 33, 0.35);
+}
+
+.custom-style-toggle-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.custom-style-toggle .toggle-title {
+  font-size: 1.45rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.custom-style-toggle .toggle-subtitle {
+  font-size: 1.2rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+.custom-style-toggle-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(7, 9, 14, 0.6);
+  transition: transform 0.3s ease, background 0.3s ease, border-color 0.3s ease;
+}
+
+.custom-style-toggle-icon::before,
+.custom-style-toggle-icon::after {
+  content: '';
+  position: absolute;
+  width: 14px;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.custom-style-toggle-icon::after {
+  transform: rotate(90deg);
+}
+
+.custom-style-toggle.is-open .custom-style-toggle-icon {
+  background: rgba(246, 168, 33, 0.18);
+  border-color: rgba(246, 168, 33, 0.5);
+}
+
+.custom-style-toggle.is-open {
+  background: linear-gradient(135deg, rgba(246, 168, 33, 0.28), rgba(255, 255, 255, 0.12));
+  box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.custom-style-toggle.is-open .custom-style-toggle-icon::after {
+  transform: rotate(90deg) scaleX(0);
+  opacity: 0;
+}
+
+.custom-style-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  padding: 2rem 2rem 2.4rem;
+  animation: panel-reveal 0.35s ease;
+}
+
+.custom-style-panel[hidden] {
+  display: none !important;
+}
+
+.custom-style-builder.is-open {
+  border-color: rgba(246, 168, 33, 0.45);
+  box-shadow: 0 24px 48px rgba(246, 168, 33, 0.12);
+}
+
+@keyframes panel-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.custom-style-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.8rem;
+  padding: 2.2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(7, 9, 14, 0.78);
+  backdrop-filter: blur(18px);
+}
+
+.custom-style-grid {
+  display: grid;
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.field-span {
+  grid-column: 1 / -1;
+}
+
+.custom-style-form input,
+.custom-style-form textarea {
+  width: 100%;
+  padding: 1.1rem 1.3rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  font: inherit;
+}
+
+.custom-style-form textarea {
+  resize: vertical;
+  min-height: 90px;
+}
+
+.builder-hint {
+  font-size: 1.25rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.builder-lists {
+  display: grid;
+  gap: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.builder-fieldset {
+  margin: 0;
+  padding: 1.6rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.builder-fieldset legend {
+  font-size: 1.2rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 0 0.4rem;
+}
+
+.builder-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-height: 240px;
+  overflow-y: auto;
+  padding-right: 0.4rem;
+}
+
+.builder-item {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 10, 16, 0.72);
+}
+
+.builder-item input[type="checkbox"] {
+  margin-top: 0.4rem;
+  width: var(--checkbox-size);
+  height: var(--checkbox-size);
+  accent-color: var(--primary);
+}
+
+.builder-item-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.builder-title {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.builder-meta {
+  font-size: 1.2rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.builder-description {
+  font-size: 1.25rem;
+  color: var(--text-muted);
+}
+
+.builder-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+}
+
+.builder-status {
+  font-size: 1.2rem;
+  color: var(--text-muted);
+  min-height: 1.4rem;
+}
+
+.builder-status.is-error {
+  color: #f26d6d;
+}
+
+.style-instructions h4 {
+  margin: 0;
+  font-size: 1.6rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.style-instructions p {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--text-muted);
+}
+
+.style-meta-row--aggregate {
+  justify-content: flex-start;
+  gap: 1.2rem;
+}
+
+.style-multi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+}
+
+.style-multi-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.6rem 1.8rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 15, 22, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.style-multi-card h5 {
+  margin: 0;
+  font-size: 1.4rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.style-multi-summary {
+  margin: 0;
+  font-size: 1.3rem;
+  color: var(--text-muted);
+}
+
+.style-multi-card .style-selection-groups {
+  margin-top: 0.8rem;
+}
+
+.style-subheading {
+  margin: 0;
+  font-size: 1.2rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.style-coaching-list {
+  margin: 0;
+  padding-left: 1.6rem;
+  display: grid;
+  gap: 0.8rem;
+  color: var(--text-muted);
+  font-size: 1.3rem;
+}
+
+.style-selection-groups {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.style-chip-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.style-selection-title {
+  font-size: 1.1rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.style-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.style-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 1.2rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.style-chip.empty {
+  opacity: 0.55;
+}
+
+.style-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.style-tag {
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  padding: 0.3rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.library-list {
+  display: grid;
+  gap: 1.2rem;
+  max-height: 48rem;
+  overflow-y: auto;
+  padding-right: 0.6rem;
+}
+
+.library-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 1.6rem;
+  padding: 1.4rem 1.6rem;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.library-item:hover,
+.library-item:focus-within {
+  border-color: rgba(246, 168, 33, 0.4);
+  background: rgba(246, 168, 33, 0.08);
+}
+
+.library-item input[type="checkbox"] {
+  margin-top: 0.4rem;
+  width: var(--checkbox-size);
+  height: var(--checkbox-size);
+  accent-color: var(--primary);
+}
+
+.item-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.item-content .title {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.item-content .meta {
+  font-size: 1.2rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--text-muted);
+}
+
+.item-content .description {
+  margin: 0;
+  font-size: 1.3rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 1180px) {
+  .training-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 3.2rem;
+  }
+
+  .library-pane {
+    order: -1;
+  }
+
+  .round-controls .btn {
+    flex: 1 1 140px;
+  }
+
+  .style-card-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .round-console {
+    padding: 2.4rem;
+  }
+
+  .round-settings {
+    grid-template-columns: 1fr;
+  }
+
+  .selection-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .library-section {
+    padding: 2rem;
+  }
+
+  .style-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+
+}


### PR DESCRIPTION
## Summary
- remove the standalone combination and technique checkbox libraries in favor of managing the round pool through signature styles
- add multi-select signature style cards with clear controls and combined instructions so multiple fighters can feed the timer at once
- restyle the signature library as a scrollable 4x4 grid and update the custom builder to reflect the new workflow

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d5c47557648331891918b17f961c3c