### PR TITLE
Enable scrolling in style library

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,12 +185,14 @@
                   <button type="button" id="clearStyles" class="link-button">Clear all styles</button>
                 </div>
                 <div class="style-grid-wrapper">
-                  <div
-                    class="style-card-grid"
-                    id="styleLibrary"
-                    role="list"
-                    aria-labelledby="styleLibraryLabel"
-                  ></div>
+                  <div class="style-scroll-area">
+                    <div
+                      class="style-card-grid"
+                      id="styleLibrary"
+                      role="list"
+                      aria-labelledby="styleLibraryLabel"
+                    ></div>
+                  </div>
                 </div>
                 <div class="style-instructions" id="styleInstructions" aria-live="polite">
                   <h4>Load a style to study the blueprint.</h4>

--- a/styles.css
+++ b/styles.css
@@ -1267,6 +1267,35 @@ main {
   width: 100%;
 }
 
+.style-scroll-area {
+  height: 100%;
+  overflow-y: auto;
+  padding-right: 1.2rem;
+  scrollbar-gutter: stable both-edge;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(246, 168, 33, 0.65) rgba(255, 255, 255, 0.08);
+  overscroll-behavior-y: contain;
+}
+
+.style-scroll-area::-webkit-scrollbar {
+  width: 10px;
+}
+
+.style-scroll-area::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+}
+
+.style-scroll-area::-webkit-scrollbar-thumb {
+  background: rgba(246, 168, 33, 0.7);
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 2px rgba(11, 13, 19, 0.85);
+}
+
+.style-scroll-area::-webkit-scrollbar-thumb:hover {
+  background: rgba(246, 168, 33, 0.85);
+}
+
 .assistive-text {
   font-size: 1.2rem;
   color: var(--text-muted);
@@ -1277,20 +1306,7 @@ main {
   display: flex;
   flex-direction: column;
   gap: 1.2rem;
-  max-height: 100%;
   height: 100%;
-  overflow-y: auto;
-  padding-right: 0.6rem;
-  scrollbar-gutter: stable;
-}
-
-.style-card-grid::-webkit-scrollbar {
-  width: 6px;
-}
-
-.style-card-grid::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.18);
-  border-radius: 999px;
 }
 
 .style-card {


### PR DESCRIPTION
## Summary
- wrap the signature style library cards in a dedicated scroll container
- style the vertical scrollbar so the library can be scrolled with a visible sidebar

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68d769a236a48331a51fe8a9a9e37185